### PR TITLE
Manual test pass: fix the crash, wire up five dead settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,32 @@ Things that cost time to learn and are not visible in the code.
   `.regularMaterial` for the panel's real backdrop.
 - `screencapture` has no Screen Recording grant in this environment, so live windows
   cannot be checked without the user looking.
+- The Accessibility API is the way to drive the running app: `AXUIElementPerformAction`
+  presses real controls, and the whole UI is well labelled, so a dump reads like the
+  screen. Two limits are worth knowing before trusting an empty result.
+  - **A locked screen empties `AXWindows` for every app on the machine**, and it looks
+    exactly like the app failing to publish anything. It is not the whole API that
+    goes: menu bar extras keep answering, and the status item's live value can be read
+    minutes after the lock in the same process that enumerates no windows. So a
+    successful AX read is not evidence the screen is unlocked, and window enumeration
+    coming back empty is not evidence of a bug. Check `CGSSessionScreenIsLocked` from
+    `CGSessionCopyCurrentDictionary` and confirm against a control app you know has
+    windows. Two of us independently invented app-shaped explanations for this, one
+    blaming `makeKey()` and one blaming activation state, and both fit the poisoned
+    data perfectly.
+  - An app with **no window open** reports an `AXWindows` array holding the
+    application element itself. Walking it naively never terminates.
+- Synthesised input does not cover everything. `CGEvent` mouse clicks reach ordinary
+  windows but not the menu bar, so the status item's left and right click paths need a
+  human. Synthesised key events do not trigger Carbon hot keys at all, whatever the tap
+  or event-source state, so a recorded global shortcut can only be confirmed by a real
+  key press.
+- `swift build --scratch-path <dir>` gives a trustworthy build without `rm -rf .build`,
+  which matters when the stale-object problem above bites and something else is using
+  the shared build directory.
+- `HOME` does not redirect `applicationSupportDirectory`, so launching with a fake home
+  does not isolate a test instance from the real settings file. `SettingsStore(directory:)`
+  is the only thing that does.
 - Contract tests read real sensors. The fan minimum-RPM test flakes during spin-down
   (1 RPM tolerance against the SMC's stated minimum). Re-run before investigating.
 

--- a/Package.swift
+++ b/Package.swift
@@ -33,9 +33,13 @@ let package = Package(
             dependencies: ["AirStatKit", "AirStatUI"],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
+        // Named for AirStatKit because that is where almost everything under test
+        // lives, but it also links AirStatUI: the pieces of UI logic worth testing
+        // are the pure ones (threshold evaluation, render models), and giving them a
+        // second test target would split the suite for no gain.
         .testTarget(
             name: "AirStatKitTests",
-            dependencies: ["AirStatKit"],
+            dependencies: ["AirStatKit", "AirStatUI"],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
     ]

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -6,6 +6,9 @@
 	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>AirStats</string>
+	<!-- Deliberately still the pre-rename identifier. It keys the UserDefaults domain,
+	     the login item and ~/Library/Application Support/AirStat, so changing it to
+	     match the new name would orphan every existing user's settings. -->
 	<key>CFBundleIdentifier</key>
 	<string>com.airstat.AirStat</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -31,9 +31,16 @@ fi
 # SwiftPM emits the UI target's resources as a bundle beside the binary. It has to
 # travel into Contents/Resources or `Bundle.module` finds nothing at runtime and the
 # app launches without its own mark.
-for bundle in "$BIN_DIR"/*_AirStatUI.bundle; do
-  [ -d "$bundle" ] && cp -R "$bundle" "$APP/Contents/Resources/"
-done
+#
+# Named exactly rather than globbed: a tree built under an earlier package name leaves
+# that name's bundle in the bin directory forever, and a glob ships both.
+BUNDLE="$BIN_DIR/AirStats_AirStatUI.bundle"
+if [ -d "$BUNDLE" ]; then
+  cp -R "$BUNDLE" "$APP/Contents/Resources/"
+else
+  echo "error: $BUNDLE is missing; the app would launch with no logo" >&2
+  exit 1
+fi
 
 # Ad-hoc signature. Without any signature macOS refuses some window-server
 # privileges a status item needs.

--- a/Sources/AirStatKit/Collectors/NetworkCollector.swift
+++ b/Sources/AirStatKit/Collectors/NetworkCollector.swift
@@ -105,7 +105,18 @@ public final class NetworkCollector: MetricSource {
     private var lastWiFiRead: ContinuousClock.Instant?
     private var wifiInterfaceName: String?
 
+    /// Owns the one outbound request this app makes. Idle until the user turns
+    /// `general.fetchesPublicIP` on; see `PublicIPFetcher` for the endpoint and the
+    /// throttle, both of which are its business rather than this collector's.
+    private let publicIPLookup = PublicIPFetcher()
+
     public init() {}
+
+    /// Pushed in from `SamplingCore` when the setting changes, because a collector has
+    /// no way to read the settings store and no business acquiring one.
+    func setPublicIPLookupEnabled(_ enabled: Bool) {
+        publicIPLookup.setEnabled(enabled)
+    }
 
     public func start() {
         autoreleasepool { acquire() }
@@ -263,6 +274,11 @@ public final class NetworkCollector: MetricSource {
         // interval and the link quality is re-read on the first sample after a wake.
         refreshWiFi(force: false, linkIsUp: wifiLinkIsUp)
 
+        // Returns immediately whether or not it starts anything: the round trip belongs
+        // to URLSession's queues, so nothing behind us on the sampling queue waits for
+        // a server on the far side of the internet.
+        publicIPLookup.refreshIfDue()
+
         let primaryName = primaryInterfaceName()
         let primary = primaryName.flatMap { name in stats.first { $0.name == name } }
         sort(&stats, primaryName: primaryName)
@@ -279,11 +295,11 @@ public final class NetworkCollector: MetricSource {
             connectionType: primary?.type ?? .none,
             wifi: wifi,
             localIPv4: primary?.ipv4,
-            // Deliberately not fetched here: `collect()` runs on the shared sampling
-            // queue, so an HTTP round trip would block every other collector behind it,
-            // and silently contacting a third party is not something a sampling tick
-            // should do. A separate opt-in, heavily throttled fetcher owns this field.
-            publicIP: .pending,
+            // Never fetched inline: `collect()` runs on the shared sampling queue, so an
+            // HTTP round trip would block every other collector behind it, and silently
+            // contacting a third party is not something a sampling tick should do. This
+            // is the cached answer of the opt-in fetcher above, read under its lock.
+            publicIP: publicIPLookup.currentState(),
             isVPNActive: vpnActive))
     }
 

--- a/Sources/AirStatKit/Core/MetricsEngine.swift
+++ b/Sources/AirStatKit/Core/MetricsEngine.swift
@@ -40,7 +40,13 @@ public final class MetricsEngine {
     private var isOverlayVisible = false
     private var isMenuBarOccluded = false
     private var isSystemAsleep = false
+    /// Established by `beginObservingPowerState()` rather than at init, so the engine's
+    /// low-power state has exactly one entry point.
+    private var isLowPowerMode = false
+    /// Snapshots ingested, counted only as far as `isLowPowerPaused` needs.
+    private var ingestCount = 0
     private var observationTask: Task<Void, Never>?
+    private var powerStateObserver: NSObjectProtocol?
 
     public init(settingsStore: SettingsStore) {
         self.settingsStore = settingsStore
@@ -60,11 +66,19 @@ public final class MetricsEngine {
         applySettings()
         core.start()
         beginObservingSettings()
+        beginObservingPowerState()
     }
+
+    /// True while the power-state observer is installed. The notification centre keeps
+    /// block observers alive until they are removed and nothing looks wrong when one
+    /// outlives its owner, so the state is exposed for verification rather than left
+    /// to be reasoned about.
+    public var isObservingPowerState: Bool { powerStateObserver != nil }
 
     public func stop() {
         observationTask?.cancel()
         observationTask = nil
+        endObservingPowerState()
         core?.stop()
         core = nil
     }
@@ -104,7 +118,26 @@ public final class MetricsEngine {
         updateActivity()
     }
 
+    /// Sets the Low Power Mode state. `start()` wires this to the process's own
+    /// notification; it is public so the state can be driven directly, which is the
+    /// only way to exercise the pause without changing the machine's power settings.
+    public func setLowPowerMode(_ enabled: Bool) {
+        guard enabled != isLowPowerMode else { return }
+        isLowPowerMode = enabled
+        updateActivity()
+    }
+
     public func refreshNow() { core?.sampleNow() }
+
+    /// True when the user asked for a pause, the machine is in Low Power Mode, and
+    /// there is something to freeze on.
+    ///
+    /// Rate-based collectors report nothing until their second sample, so an app
+    /// launched into an already-on Low Power Mode would pause on a menu bar reading
+    /// "unavailable". A paused app should show the last real numbers, not no numbers.
+    private var isLowPowerPaused: Bool {
+        ingestCount >= 2 && isLowPowerMode && settingsStore.settings.general.pausesOnLowPower
+    }
 
     private func updateActivity() {
         let newActivity: SamplingActivity
@@ -114,6 +147,12 @@ public final class MetricsEngine {
             newActivity = .panel
         } else if isOverlayVisible {
             newActivity = .overlay
+        } else if isLowPowerPaused {
+            // Ranked below the surfaces the user opened deliberately and above the
+            // occlusion throttle: a pause is the stronger of the two power measures,
+            // but freezing a panel the user is looking at would show them stale numbers
+            // with no way to refresh, since a suspended core ignores `sampleNow`.
+            newActivity = .suspended
         } else if isMenuBarOccluded && settingsStore.settings.general.throttlesWhenOccluded {
             newActivity = .occluded
         } else {
@@ -163,10 +202,39 @@ public final class MetricsEngine {
         }
     }
 
-    private func applySettings() {
+    /// Low Power Mode is a state the user flips mid-session, so the pause has to
+    /// follow it live rather than being decided once at launch.
+    func beginObservingPowerState() {
+        guard powerStateObserver == nil else { return }
+        powerStateObserver = NotificationCenter.default.addObserver(
+            forName: .NSProcessInfoPowerStateDidChange,
+            object: nil, queue: .main) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.setLowPowerMode(ProcessInfo.processInfo.isLowPowerModeEnabled)
+                }
+        }
+        // The notification only reports changes, so the state as it stands right now
+        // has to be read out. It comes from the process rather than from
+        // `snapshot.power.isLowPowerMode`, which the power collector samples: a snapshot
+        // is a product of sampling, so a state that pauses sampling would latch on at
+        // the last sample taken and could never see itself clear.
+        setLowPowerMode(ProcessInfo.processInfo.isLowPowerModeEnabled)
+    }
+
+    func endObservingPowerState() {
+        guard let powerStateObserver else { return }
+        NotificationCenter.default.removeObserver(powerStateObserver)
+        self.powerStateObserver = nil
+    }
+
+    func applySettings() {
         let s = settingsStore.settings
         core?.setBaseInterval(s.general.updateInterval)
         core?.setEnabledSources(currentRequiredSources)
+        core?.setPublicIPLookupEnabled(s.general.fetchesPublicIP)
+        // Turning the pause off has to resume sampling now, not at whatever UI
+        // transition happens to call `updateActivity` next.
+        updateActivity()
 
         let capacity = s.historyCapacity
         if history.capacity != capacity { history.resize(to: capacity) }
@@ -177,10 +245,14 @@ public final class MetricsEngine {
 
     // MARK: Ingest
 
-    private func ingest(_ new: SystemSnapshot) {
+    func ingest(_ new: SystemSnapshot) {
         snapshot = new
         lastUpdate = new.capturedAt
         record(new)
+        guard ingestCount < 2 else { return }
+        ingestCount += 1
+        // The pause that was waiting for rates to exist can take effect now.
+        updateActivity()
     }
 
     /// Fold a snapshot into history. Only series whose metric is actually available

--- a/Sources/AirStatKit/Core/PublicIPFetcher.swift
+++ b/Sources/AirStatKit/Core/PublicIPFetcher.swift
@@ -1,0 +1,181 @@
+import Darwin
+import Foundation
+
+/// How the fetcher reaches the network. The shipping implementation is one URLSession
+/// round trip; tests substitute a closure so the throttle, the opt-in gate and the
+/// clearing behaviour can be exercised on a machine that is offline.
+public typealias PublicIPTransport =
+    @Sendable (@escaping @Sendable (MetricState<String>) -> Void) -> Void
+
+/// Looks up the machine's public IP address, off the sampling queue and only when the
+/// user has asked for it.
+///
+/// This is the only code in the app that opens a connection to anything, so it holds
+/// itself to rules the other collectors do not need:
+///
+/// - Nothing is sent until `setEnabled(true)` arrives from `general.fetchesPublicIP`,
+///   which ships off. A fetcher nobody enabled never builds a session.
+/// - `refreshIfDue()` is called from `NetworkCollector.collect()` on `SamplingCore`'s
+///   serial queue and never waits for a reply: it either returns immediately or hands
+///   the round trip to URLSession's own queues. `currentState()` reads a cached answer,
+///   so the sampling tick costs a lock and nothing else.
+/// - Turning the toggle back off drops the cached address. A withdrawn permission that
+///   leaves the last answer on screen has not really been withdrawn.
+///
+/// State is guarded by a lock rather than confined to a queue: it is written from
+/// URLSession's delegate queue and read from the sampling queue, which is exactly the
+/// case `SamplingCore`'s confinement-by-construction does not cover.
+public final class PublicIPFetcher: @unchecked Sendable {
+
+    /// Half an hour. A public address is a lease from an ISP that turns over in days on
+    /// a home line and in hours at worst, so unlike a rate it does not go stale between
+    /// samples. Thirty minutes is 48 requests a day, few enough that the pattern tells
+    /// the other end nothing beyond that the Mac is awake, and short enough that
+    /// someone who moves onto a hotspot sees the new address without relaunching.
+    public static let refreshInterval: TimeInterval = 30 * 60
+
+    /// Two minutes after a failed attempt rather than the full interval. The ordinary
+    /// failure is having no route at all, and a laptop that has just opened its lid
+    /// should not sit on "unavailable" for half an hour once the Wi-Fi associates.
+    public static let retryInterval: TimeInterval = 2 * 60
+
+    /// api.ipify.org answers with the bare address as `text/plain`: no JSON envelope,
+    /// no cookies, no redirect chain, no query string and no geolocation record that
+    /// nobody asked for. The request therefore carries nothing the TCP connection would
+    /// not already reveal, which is the least this app can ask of the one third party
+    /// it talks to.
+    public static let endpoint = URL(string: "https://api.ipify.org")!
+
+    /// Said in place of an address while the feature is off, so the panel can leave the
+    /// row out entirely instead of drawing an empty field.
+    public static let disabledMessage = "Public IP lookup is off"
+
+    private let transport: PublicIPTransport
+    private let lock = NSLock()
+    private var isEnabled = false
+    private var state: MetricState<String> = .failure(.unsupported(PublicIPFetcher.disabledMessage))
+    private var lastAttempt: ContinuousClock.Instant?
+    private var isFetching = false
+
+    /// Bumped every time the toggle moves. A reply that arrives after the user turned
+    /// the feature off carries the old generation and is discarded: the request is
+    /// already out and cannot be unsent, but its answer never reaches the screen.
+    private var generation: UInt64 = 0
+
+    public init(transport: @escaping PublicIPTransport = PublicIPFetcher.httpTransport()) {
+        self.transport = transport
+    }
+
+    /// Safe from any thread. Called on `SamplingCore`'s queue when the setting changes.
+    public func setEnabled(_ enabled: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard enabled != isEnabled else { return }
+        isEnabled = enabled
+        generation &+= 1
+        lastAttempt = nil
+        isFetching = false
+        state = enabled ? .pending : .failure(.unsupported(Self.disabledMessage))
+    }
+
+    public func currentState() -> MetricState<String> {
+        lock.lock()
+        defer { lock.unlock() }
+        return state
+    }
+
+    /// Starts a lookup if the feature is on and the cached answer is old enough.
+    /// Returns without waiting for the reply, so the caller may be the sampling queue.
+    public func refreshIfDue() {
+        lock.lock()
+        guard isEnabled, !isFetching, isDueLocked() else {
+            lock.unlock()
+            return
+        }
+        isFetching = true
+        lastAttempt = Monotonic.now
+        let generation = self.generation
+        lock.unlock()
+
+        transport { [weak self] result in
+            self?.finish(result, generation: generation)
+        }
+    }
+
+    /// Timed from the start of the last attempt, not from the answer: a request that
+    /// hangs until its timeout must not earn a second one the moment it gives up.
+    private func isDueLocked() -> Bool {
+        guard let lastAttempt else { return true }
+        let interval = state.isAvailable ? Self.refreshInterval : Self.retryInterval
+        return Monotonic.seconds(since: lastAttempt) >= interval
+    }
+
+    private func finish(_ result: MetricState<String>, generation: UInt64) {
+        lock.lock()
+        defer { lock.unlock() }
+        guard generation == self.generation, isEnabled else { return }
+        isFetching = false
+        state = result
+    }
+
+    // MARK: Transport
+
+    /// The shipping transport.
+    ///
+    /// The session is ephemeral: no cookie jar, no credential store and no disk cache
+    /// outlive the request, so the lookup leaves nothing behind on this machine either.
+    /// `waitsForConnectivity` is off on purpose, because an offline Mac should say it
+    /// could not reach the endpoint rather than hold a request open until the network
+    /// comes back and then report an address minutes late.
+    public static func httpTransport(endpoint: URL = PublicIPFetcher.endpoint) -> PublicIPTransport {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.httpShouldSetCookies = false
+        configuration.httpCookieAcceptPolicy = .never
+        configuration.urlCache = nil
+        configuration.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+        configuration.waitsForConnectivity = false
+        configuration.timeoutIntervalForRequest = 10
+        configuration.timeoutIntervalForResource = 15
+        let session = URLSession(configuration: configuration)
+
+        return { completion in
+            var request = URLRequest(url: endpoint)
+            request.httpMethod = "GET"
+            // CFNetwork's default agent string spells out the OS build and the app
+            // version. A fixed name says who is asking without describing the machine.
+            request.setValue("AirStats", forHTTPHeaderField: "User-Agent")
+            request.setValue("text/plain", forHTTPHeaderField: "Accept")
+            session.dataTask(with: request) { data, response, error in
+                completion(interpret(data: data, response: response, error: error))
+            }.resume()
+        }
+    }
+
+    static func interpret(data: Data?, response: URLResponse?, error: Error?) -> MetricState<String> {
+        if let error {
+            return .failure(.failed("could not reach the lookup service: \(error.localizedDescription)"))
+        }
+        if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            return .failure(.failed("the lookup service answered HTTP \(http.statusCode)"))
+        }
+        guard let data, let text = String(data: data, encoding: .utf8) else {
+            return .failure(.failed("the lookup service returned no address"))
+        }
+        // A captive portal answers every request with its own login page, and a 200 of
+        // HTML is the usual shape of that. Nothing reaches the panel unless it parses
+        // as an address.
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isIPAddress(trimmed) else {
+            return .failure(.failed("the reply was not an IP address"))
+        }
+        return .value(trimmed)
+    }
+
+    static func isIPAddress(_ text: String) -> Bool {
+        guard !text.isEmpty, text.utf8.count < 64 else { return false }
+        var v4 = in_addr()
+        if inet_pton(AF_INET, text, &v4) == 1 { return true }
+        var v6 = in6_addr()
+        return inet_pton(AF_INET6, text, &v6) == 1
+    }
+}

--- a/Sources/AirStatKit/Core/SamplingCore.swift
+++ b/Sources/AirStatKit/Core/SamplingCore.swift
@@ -194,6 +194,15 @@ public final class SamplingCore: @unchecked Sendable {
         }
     }
 
+    /// Turns the public IP lookup on or off. The one collector behaviour the user has
+    /// to opt into, so it is pushed down here rather than read from settings by the
+    /// collector: this queue is the only place a collector's state may be touched.
+    public func setPublicIPLookupEnabled(_ enabled: Bool) {
+        queue.async { [self] in
+            networkSlot.source.setPublicIPLookupEnabled(enabled)
+        }
+    }
+
     /// Called on wake from sleep: cumulative counters may have reset and every
     /// rate is meaningless until re-baselined.
     public func noteWakeFromSleep() {

--- a/Sources/AirStatKit/Settings/SettingsStore.swift
+++ b/Sources/AirStatKit/Settings/SettingsStore.swift
@@ -57,9 +57,14 @@ public final class SettingsStore {
         SettingsStore.currentTheme = loaded.theme
     }
 
+    /// Note that `HOME` does not redirect `applicationSupportDirectory`, so a test
+    /// instance cannot be isolated by launching it with a fake home. Pass `directory:`
+    /// instead; it is the only thing that keeps a test off the user's real settings.
     public nonisolated static var defaultDirectory: URL {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
             ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/Application Support")
+        // Deliberately still "AirStat" after the rename, for the same reason the bundle
+        // identifier is: renaming it would strand every existing user's settings.
         let dir = base.appendingPathComponent("AirStat", isDirectory: true)
         try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         return dir

--- a/Sources/AirStatKit/Support/HotKeyTranslation.swift
+++ b/Sources/AirStatKit/Support/HotKeyTranslation.swift
@@ -1,0 +1,52 @@
+import AppKit
+import Carbon.HIToolbox
+
+/// Turns a recorded `KeyboardShortcut` into the two values `RegisterEventHotKey` takes.
+///
+/// The recorder stores the modifiers as an `NSEvent.ModifierFlags` bitmask. Carbon
+/// predates that type and carries a bitmask of its own with entirely different bit
+/// positions, so the two share nothing but their meaning and have to be mapped by hand.
+extension KeyboardShortcut {
+
+    /// Carbon's virtual key codes are the same `kVK_` values `NSEvent` reports, so the
+    /// key code needs a width change and nothing more.
+    public var carbonKeyCode: UInt32 { UInt32(keyCode) }
+
+    /// Caps Lock, Fn and the numeric-keypad bit are dropped. They describe the state
+    /// the keyboard happened to be in, not part of the chord, and carrying them
+    /// through would produce a hot key that only fires while Caps Lock is on.
+    public var carbonModifierFlags: UInt32 {
+        let flags = NSEvent.ModifierFlags(rawValue: modifierFlags)
+        var carbon: UInt32 = 0
+        if flags.contains(.command) { carbon |= UInt32(cmdKey) }
+        if flags.contains(.option) { carbon |= UInt32(optionKey) }
+        if flags.contains(.control) { carbon |= UInt32(controlKey) }
+        if flags.contains(.shift) { carbon |= UInt32(shiftKey) }
+        return carbon
+    }
+
+    /// Whether this combination is safe to claim system-wide.
+    ///
+    /// A bare key, or Shift plus a key, would swallow that keystroke everywhere the
+    /// user types. The recorder refuses to record one, but a hand-edited or imported
+    /// settings file can still contain one and must not be registered.
+    public var isGloballyRegisterable: Bool {
+        let flags = NSEvent.ModifierFlags(rawValue: modifierFlags)
+        return !flags.intersection([.command, .option, .control]).isEmpty
+    }
+}
+
+extension ShortcutAction {
+
+    /// Carbon identifies a registered hot key by a number, and hands that number back
+    /// when the chord is pressed. Derived from the case's position so that adding an
+    /// action cannot collide with an existing one, and so there is no hand-kept table
+    /// to drift out of step with the enum.
+    public var hotKeyIdentifier: UInt32 {
+        UInt32((ShortcutAction.allCases.firstIndex(of: self) ?? 0) + 1)
+    }
+
+    public static func action(forHotKeyIdentifier identifier: UInt32) -> ShortcutAction? {
+        allCases.first { $0.hotKeyIdentifier == identifier }
+    }
+}

--- a/Sources/AirStatKit/Support/MetricProbe.swift
+++ b/Sources/AirStatKit/Support/MetricProbe.swift
@@ -53,7 +53,7 @@ public enum MetricProbe {
         startIfNeeded(network); startIfNeeded(disk); startIfNeeded(power)
         startIfNeeded(thermal); startIfNeeded(processes); startIfNeeded(system)
 
-        emit("AirStat metric probe")
+        emit("AirStats metric probe")
         emit("collectors: \(options.collectors.map(\.rawValue).sorted().joined(separator: ", "))")
         emit("samples: \(options.repeatCount) every \(options.interval)s")
         emit(String(repeating: "─", count: 68))
@@ -197,6 +197,9 @@ public enum MetricProbe {
             "since boot   ↓ \(fmt.bytes(s.totalDownloadBytes))  ↑ \(fmt.bytes(s.totalUploadBytes))",
             "primary      \(s.primaryInterfaceName ?? "—") (\(s.connectionType.label))  vpn=\(s.isVPNActive)",
             "address      \(s.localIPv4 ?? "—")",
+            // The probe builds its own collector, so the lookup is off here unless a
+            // test turns it on. Printing the state is how that stays visible.
+            "public ip    \(s.publicIP.value ?? failureKind(s.publicIP.failure ?? .pending))",
         ]
         if let wifi = s.wifi {
             lines.append("wi-fi        ssid=\(wifi.ssid ?? "—") rssi=\(wifi.rssi.map(String.init) ?? "—") "

--- a/Sources/AirStatKit/Support/SnapshotFixtures.swift
+++ b/Sources/AirStatKit/Support/SnapshotFixtures.swift
@@ -149,7 +149,9 @@ public enum SnapshotFixtures {
                            channel: 6, band: "2.4 GHz", transmitRateMbps: 229,
                            security: "WPA3 Personal"),
             localIPv4: "10.0.0.69",
-            publicIP: .failure(.unsupported("Public IP lookup is off")),
+            // A documentation-range address (RFC 5737), so the fixture shows the row the
+            // opt-in lookup fills in without any machine's real address in the source.
+            publicIP: .value("203.0.113.42"),
             isVPNActive: false
         )
     }

--- a/Sources/AirStatUI/MenuBar/StatusItemController.swift
+++ b/Sources/AirStatUI/MenuBar/StatusItemController.swift
@@ -2,11 +2,39 @@ import AppKit
 import AirStatKit
 import Observation
 
-/// Owns the `NSStatusItem` and the custom view drawn inside it.
+/// What the menu bar is currently made of.
+///
+/// Either one item drawing every readout, or one item per enabled readout in the
+/// user's order. Derived from settings and compared as a whole, so flipping the
+/// combine switch or enabling a readout is a single value change the controller can
+/// act on without inspecting anything else.
+enum MenuBarItemLayout: Equatable {
+    case combined
+    case separate([UUID])
+
+    init(settings: MenuBarSettings) {
+        let enabled = settings.enabledItems.map(\.id)
+        // Separate items with nothing enabled would put no item on the bar at all, and
+        // with it no way back into the app short of a hot key. The combined item draws
+        // an empty readout at a clickable minimum width, so it stands in.
+        guard !settings.usesCombinedItem, !enabled.isEmpty else {
+            self = .combined
+            return
+        }
+        self = .separate(enabled)
+    }
+}
+
+/// Owns the app's `NSStatusItem`s and the custom views drawn inside them.
 ///
 /// The menu bar is the most scrutinised surface in the app: it sits two pixels from
 /// Apple's own glyphs, redraws constantly, and must never jitter, blur, or push its
 /// neighbours around. Everything here exists to serve that.
+///
+/// There is one item per enabled readout when the user has turned the combine switch
+/// off, and one item for all of them when it is on. Separate items are what let the
+/// user drag a readout to sit beside Wi-Fi rather than beside our other numbers, and
+/// what lets macOS drop them one at a time instead of losing the whole bar at once.
 @MainActor
 public final class StatusItemController {
 
@@ -16,11 +44,23 @@ public final class StatusItemController {
 
     private let engine: MetricsEngine
     private let settings: SettingsStore
-    private var statusItem: NSStatusItem?
-    private var contentView: MenuBarContentView?
+    private var hosted: [Hosted] = []
+    private var layout: MenuBarItemLayout?
+    /// The item the user last clicked. Everything anchored to "the status item" means
+    /// this one, because with several of them the only sensible answer is the one the
+    /// user just touched.
+    private var activeItem: NSStatusItem?
     private var renderTask: Task<Void, Never>?
-    private var visibilityObservation: NSKeyValueObservation?
     private var lastReportedVisibility: Bool?
+
+    /// One status item and the view drawing into it. `readout` is the id of the single
+    /// readout it draws, or nil for the combined item, which draws them all.
+    private struct Hosted {
+        let readout: UUID?
+        let item: NSStatusItem
+        let content: MenuBarContentView
+        let visibility: NSKeyValueObservation
+    }
 
     public init(engine: MetricsEngine, settings: SettingsStore) {
         self.engine = engine
@@ -30,17 +70,86 @@ public final class StatusItemController {
     // MARK: Installation
 
     public func install() {
-        guard statusItem == nil else { return }
+        syncLayout()
+        beginRendering()
+        render()
+    }
+
+    public func remove() {
+        renderTask?.cancel()
+        renderTask = nil
+        tearDownItems()
+        layout = nil
+    }
+
+    /// The combined item keeps the name it has always had, so an install that predates
+    /// separate items does not lose the position the user dragged it to.
+    static let combinedAutosaveName = "AirStatStatusItem"
+
+    /// Per-readout items are keyed by the readout's own id rather than by its metric.
+    /// Two readouts of the same metric are allowed, and keyed by metric they would
+    /// share one saved position and fight over it. The consequence is that turning a
+    /// readout off and back on returns it to where the user dragged it, since that
+    /// keeps the config and its id, while deleting one and adding it again mints a new
+    /// id and starts from the default position, which is what a new readout should do.
+    static func autosaveName(for readout: UUID) -> String {
+        "\(combinedAutosaveName)-\(readout.uuidString)"
+    }
+
+    /// Brings the installed items in line with the settings. A no-op unless the combine
+    /// switch moved or the set of enabled readouts changed, so an unrelated settings
+    /// write costs one comparison and no menu bar churn.
+    ///
+    /// When it does change, every item is rebuilt rather than the difference applied.
+    /// Placement is the reason: an item is only ever inserted at the end of our run, so
+    /// keeping the survivors and appending a newly enabled readout would put it at one
+    /// end of the bar instead of in the slot the user put it in. Rebuilding puts the
+    /// whole run back in order, and anything the user has dragged elsewhere returns to
+    /// where they dragged it from its autosaved position.
+    private func syncLayout() {
+        let desired = MenuBarItemLayout(settings: settings.settings.menuBar)
+        guard desired != layout else { return }
+        tearDownItems()
+        layout = desired
+
+        switch desired {
+        case .combined:
+            if let entry = makeItem(readout: nil,
+                                    autosaveName: StatusItemController.combinedAutosaveName,
+                                    label: "AirStats system statistics") {
+                hosted = [entry]
+            }
+
+        case .separate:
+            // Built back to front: an item with no saved position lands to the left of
+            // the ones already on the bar, so making the last readout first leaves the
+            // first one leftmost and the configured order reads left to right. A
+            // readout the user has since dragged somewhere else keeps that position.
+            let configs = settings.settings.menuBar.enabledItems
+            let built = configs.reversed().compactMap { config in
+                makeItem(readout: config.id,
+                         autosaveName: StatusItemController.autosaveName(for: config.id),
+                         label: "AirStats \(config.metric.label)")
+            }
+            hosted = built.reversed()
+        }
+        reportVisibility()
+    }
+
+    private func makeItem(readout: UUID?, autosaveName: String, label: String) -> Hosted? {
         let item = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         item.behavior = [.removalAllowed]
-        item.autosaveName = "AirStatStatusItem"
+        item.autosaveName = autosaveName
 
-        guard let button = item.button else { return }
+        guard let button = item.button else {
+            NSStatusBar.system.removeStatusItem(item)
+            return nil
+        }
         button.target = self
         button.action = #selector(handleClick(_:))
         button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         button.setAccessibilityRole(.button)
-        button.setAccessibilityLabel("AirStats system statistics")
+        button.setAccessibilityLabel(label)
 
         let content = MenuBarContentView(frame: .zero)
         content.translatesAutoresizingMaskIntoConstraints = false
@@ -52,43 +161,48 @@ public final class StatusItemController {
             content.bottomAnchor.constraint(equalTo: button.bottomAnchor),
         ])
 
-        self.statusItem = item
-        self.contentView = content
-
-        observeVisibility(of: item)
-        beginRendering()
-        render()
+        return Hosted(readout: readout, item: item, content: content,
+                      visibility: observeVisibility(of: item))
     }
 
-    public func remove() {
-        renderTask?.cancel()
-        renderTask = nil
-        visibilityObservation?.invalidate()
-        visibilityObservation = nil
-        if let statusItem { NSStatusBar.system.removeStatusItem(statusItem) }
-        statusItem = nil
-        contentView = nil
+    /// Every item goes, observations first: a `removeStatusItem` fires the visibility
+    /// observer on the way out, and reporting a bar that is only half torn down as
+    /// invisible would throttle sampling for the moment it takes to build the new one.
+    private func tearDownItems() {
+        for entry in hosted {
+            entry.visibility.invalidate()
+            NSStatusBar.system.removeStatusItem(entry.item)
+        }
+        hosted.removeAll()
+        activeItem = nil
     }
 
     // MARK: Geometry
 
-    /// Screen-space rect of the status item button, for anchoring the panel.
-    /// Nil when the item is not currently on screen.
+    /// Screen-space rect of the status item button the panel should hang from, which is
+    /// the one the user last clicked. Nil when the item is not currently on screen.
     public var anchorRect: NSRect? {
-        guard let button = statusItem?.button, let window = button.window else { return nil }
+        guard let button = anchorItem?.button, let window = button.window else { return nil }
         return window.convertToScreen(button.convert(button.bounds, to: nil))
     }
 
     public var anchorScreen: NSScreen? {
-        statusItem?.button?.window?.screen ?? NSScreen.main
+        anchorItem?.button?.window?.screen ?? NSScreen.main
+    }
+
+    /// The last item clicked, or the first one when the panel is being opened by a hot
+    /// key or a menu rather than by a click.
+    private var anchorItem: NSStatusItem? {
+        if let activeItem, hosted.contains(where: { $0.item === activeItem }) { return activeItem }
+        return hosted.first?.item
     }
 
     public func presentMenu(_ menu: NSMenu) {
-        guard let statusItem else { return }
-        statusItem.menu = menu
-        statusItem.button?.performClick(nil)
+        guard let item = anchorItem else { return }
+        item.menu = menu
+        item.button?.performClick(nil)
         // Detach immediately so the next left-click goes back to our action.
-        statusItem.menu = nil
+        item.menu = nil
     }
 
     // MARK: Visibility
@@ -96,15 +210,19 @@ public final class StatusItemController {
     /// `NSStatusItem.isVisible` goes false when the item is pushed off the menu bar
     /// (too many items, or hidden behind the notch). That is the strongest signal we
     /// have that nobody can see our readouts, so it drives sampling throttling.
-    private func observeVisibility(of item: NSStatusItem) {
-        visibilityObservation = item.observe(\.isVisible, options: [.initial, .new]) { [weak self] item, _ in
-            let visible = item.isVisible
-            Task { @MainActor [weak self] in
-                guard let self, self.lastReportedVisibility != visible else { return }
-                self.lastReportedVisibility = visible
-                self.onVisibilityChange?(visible)
-            }
+    private func observeVisibility(of item: NSStatusItem) -> NSKeyValueObservation {
+        item.observe(\.isVisible, options: [.initial, .new]) { [weak self] _, _ in
+            Task { @MainActor [weak self] in self?.reportVisibility() }
         }
+    }
+
+    /// Separate items are hidden one at a time, so one readout falling off the bar says
+    /// nothing about the rest: sampling only throttles once every item is gone.
+    private func reportVisibility() {
+        let visible = hosted.contains { $0.item.isVisible }
+        guard lastReportedVisibility != visible else { return }
+        lastReportedVisibility = visible
+        onVisibilityChange?(visible)
     }
 
     // MARK: Rendering
@@ -135,19 +253,41 @@ public final class StatusItemController {
     }
 
     private func render() {
-        guard let contentView else { return }
+        // Settings are read here rather than watched separately, so the combine switch
+        // takes effect on the same pass that redraws the numbers under it.
+        syncLayout()
+        guard !hosted.isEmpty else { return }
         let model = MenuBarRenderModel(snapshot: engine.snapshot,
                                        history: engine.history,
                                        settings: settings.settings,
                                        isStale: engine.isStale)
-        contentView.update(with: model)
-        statusItem?.length = contentView.intrinsicContentSize.width
-        statusItem?.button?.setAccessibilityValue(model.accessibilityDescription)
+        for entry in hosted {
+            let slice = StatusItemController.slice(model, readout: entry.readout)
+            entry.content.update(with: slice)
+            entry.item.length = entry.content.intrinsicContentSize.width
+            entry.item.button?.setAccessibilityValue(slice.accessibilityDescription)
+        }
+    }
+
+    /// The whole-bar model narrowed to the one readout an item draws.
+    ///
+    /// A slice of the finished model rather than a second, per-item build of it: the
+    /// item then draws exactly what it would have drawn in the combined bar, including
+    /// the joint normalisation a paired metric's graphs depend on, and each item still
+    /// redraws only when its own slice changes.
+    static func slice(_ model: MenuBarRenderModel, readout: UUID?) -> MenuBarRenderModel {
+        guard let readout else { return model }
+        var slice = model
+        slice.items = model.items.filter { $0.id == readout }
+        return slice
     }
 
     // MARK: Input
 
     @objc private func handleClick(_ sender: NSStatusBarButton) {
+        // Recorded before the action runs, because the action is what reads `anchorRect`
+        // and the panel belongs under the item that was clicked.
+        activeItem = hosted.first { $0.item.button === sender }?.item
         let event = NSApp.currentEvent
         let isSecondary = event?.type == .rightMouseUp
             || event?.modifierFlags.contains(.control) == true

--- a/Sources/AirStatUI/Panel/PanelModuleDetails.swift
+++ b/Sources/AirStatUI/Panel/PanelModuleDetails.swift
@@ -172,6 +172,12 @@ extension PanelModuleView {
         section(engine.network) { network in
             VStack(alignment: .leading, spacing: Design.Space.xs) {
                 PanelDetailGrid(entries: networkEntries(network))
+                if let publicIP = publicIPValue(network.publicIP) {
+                    // Full width rather than a grid cell, the way the battery's adapter
+                    // row is: a grid cell is half of 340pt and truncated "203.0.113…"
+                    // after the label, and an IPv6 answer is three times longer again.
+                    ReadoutRow("Public IP", publicIP)
+                }
                 if let wifi = network.wifi, let quality = wifi.signalQuality {
                     // The network's name labels its own signal bar; a row that said
                     // "Signal" and a row that said "Network" would be two lines
@@ -193,6 +199,22 @@ extension PanelModuleView {
             entries.append(PanelDetailEntry("Interface", name))
         }
         return entries
+    }
+
+    /// What the public IP row says, or nil when there should be no row at all.
+    ///
+    /// The fetcher reports `.unsupported` while the toggle is off, and that is the one
+    /// state with no row: a permanently empty field would read as a lookup that keeps
+    /// failing rather than a feature nobody asked for. The fetcher's failure text is a
+    /// sentence and this line holds a value, so the row says only which of the three
+    /// things is true: an address, a lookup in flight, or one that did not answer.
+    private func publicIPValue(_ state: MetricState<String>) -> String? {
+        switch state {
+        case .value(let address): return address
+        case .failure(.unsupported): return nil
+        case .failure(.pending): return "Looking up…"
+        case .failure: return MetricFormatter.unavailable
+        }
     }
 
     /// Signal strength with the negotiated rate beside it: the two together are what

--- a/Sources/AirStatUI/Settings/AppearancePane.swift
+++ b/Sources/AirStatUI/Settings/AppearancePane.swift
@@ -142,7 +142,7 @@ private struct ColorRow: View {
                     }
                     .buttonStyle(.link)
                     .font(.callout)
-                    .accessibilityHint("Returns \(label) to the colour AirStat ships with")
+                    .accessibilityHint("Returns \(label) to the colour AirStats ships with")
                 }
                 ColorPicker("", selection: binding, supportsOpacity: false)
                     .labelsHidden()

--- a/Sources/AirStatUI/Settings/GeneralPane.swift
+++ b/Sources/AirStatUI/Settings/GeneralPane.swift
@@ -49,7 +49,7 @@ struct GeneralPane: View {
             ShortcutsFormSections(settings: settings)
 
             Section {
-                Toggle("Open AirStat at login",
+                Toggle("Open AirStats at login",
                        isOn: settings.binding(\.general.launchAtLogin, onChange: applyLoginItem))
                 if let loginItemError {
                     SettingsCaution(loginItemError)

--- a/Sources/AirStatUI/Settings/MenuBarPane.swift
+++ b/Sources/AirStatUI/Settings/MenuBarPane.swift
@@ -20,6 +20,11 @@ struct MenuBarPane: View {
         return items.firstIndex { $0.id == selection }
     }
 
+    private var selectedItem: MenuBarItemConfig? {
+        guard let selection else { return nil }
+        return items.first { $0.id == selection }
+    }
+
     var body: some View {
         Form {
             Section {
@@ -36,8 +41,8 @@ struct MenuBarPane: View {
                 Text("Readouts")
             }
 
-            if let index = selectedIndex {
-                itemDetail(index: index)
+            if let item = selectedItem {
+                itemDetail(item)
             }
 
             Section {
@@ -169,16 +174,15 @@ struct MenuBarPane: View {
     /// "CPU Usage", it read as a section of the pane, and changing the picker while
     /// looking at a list of four readouts was a guess about which one was moving.
     @ViewBuilder
-    private func itemDetail(index: Int) -> some View {
-        let item = items[index]
+    private func itemDetail(_ item: MenuBarItemConfig) -> some View {
         Section {
-            Picker("Metric", selection: metricBinding(index: index)) {
+            Picker("Metric", selection: metricBinding(for: item)) {
                 ForEach(MenuBarMetric.allCases, id: \.self) { metric in
                     Text(metric.label).tag(metric)
                 }
             }
 
-            Picker("Display as", selection: styleBinding(index: index)) {
+            Picker("Display as", selection: styleBinding(for: item)) {
                 ForEach(item.metric.supportedStyles, id: \.self) { style in
                     Text(style.label).tag(style)
                 }
@@ -189,7 +193,7 @@ struct MenuBarPane: View {
             // a caption to add and the toggle would do nothing if shown.
             if item.style != .iconAndText {
                 Toggle("Show \"\(caption(for: item.metric))\" above the value",
-                       isOn: captionBinding(index: index))
+                       isOn: captionBinding(for: item))
             }
         } header: {
             Label("Editing \(item.metric.label)", systemImage: "slider.horizontal.3")
@@ -209,52 +213,52 @@ struct MenuBarPane: View {
 
     // MARK: Model access
 
-    /// Bindings are index-based rather than id-based so a rename or reorder cannot
-    /// silently write to the wrong item.
-    private func enabledBinding(for item: MenuBarItemConfig) -> Binding<Bool> {
-        Binding(get: { item.isEnabled },
-                set: { isOn in
-                    settings.update { s in
-                        guard let index = s.menuBar.items.firstIndex(where: { $0.id == item.id }) else { return }
-                        s.menuBar.items[index].isEnabled = isOn
-                    }
-                })
+    /// Bindings carry the item's id rather than its position, so a rename or reorder
+    /// cannot silently write to whichever readout now sits at that index.
+    ///
+    /// The getters answer from the captured item instead of going back to the array.
+    /// SwiftUI reads a `Picker`'s selection during the same update pass that replaces
+    /// the list, before the pane's body has had a chance to drop the editing section,
+    /// so a getter that subscripted by index would trap on anything that shortens
+    /// `menuBar.items` under the editor: Restore Defaults, or an import. The metric,
+    /// style and caption factories are internal rather than private so the regression
+    /// test can hold a binding across exactly that reset.
+    private func mutate(_ item: MenuBarItemConfig,
+                        _ body: @escaping (inout MenuBarItemConfig) -> Void) {
+        settings.update { s in
+            guard let index = s.menuBar.items.firstIndex(where: { $0.id == item.id }) else { return }
+            body(&s.menuBar.items[index])
+        }
     }
 
-    private func metricBinding(index: Int) -> Binding<MenuBarMetric> {
-        Binding(get: { items[index].metric },
+    private func enabledBinding(for item: MenuBarItemConfig) -> Binding<Bool> {
+        Binding(get: { item.isEnabled },
+                set: { isOn in mutate(item) { $0.isEnabled = isOn } })
+    }
+
+    func metricBinding(for item: MenuBarItemConfig) -> Binding<MenuBarMetric> {
+        Binding(get: { item.metric },
                 set: { metric in
-                    settings.update { s in
-                        guard s.menuBar.items.indices.contains(index) else { return }
-                        s.menuBar.items[index].metric = metric
+                    mutate(item) { config in
+                        config.metric = metric
                         // `sanitized()` in the store will clamp an unsupported style,
                         // but doing it here keeps the picker from flashing a value it
                         // is about to lose.
-                        if !metric.supportedStyles.contains(s.menuBar.items[index].style) {
-                            s.menuBar.items[index].style = metric.supportedStyles.first ?? .text
+                        if !metric.supportedStyles.contains(config.style) {
+                            config.style = metric.supportedStyles.first ?? .text
                         }
                     }
                 })
     }
 
-    private func styleBinding(index: Int) -> Binding<MenuBarDisplayStyle> {
-        Binding(get: { items[index].style },
-                set: { style in
-                    settings.update { s in
-                        guard s.menuBar.items.indices.contains(index) else { return }
-                        s.menuBar.items[index].style = style
-                    }
-                })
+    func styleBinding(for item: MenuBarItemConfig) -> Binding<MenuBarDisplayStyle> {
+        Binding(get: { item.style },
+                set: { style in mutate(item) { $0.style = style } })
     }
 
-    private func captionBinding(index: Int) -> Binding<Bool> {
-        Binding(get: { items[index].showsCaption },
-                set: { shows in
-                    settings.update { s in
-                        guard s.menuBar.items.indices.contains(index) else { return }
-                        s.menuBar.items[index].showsCaption = shows
-                    }
-                })
+    func captionBinding(for item: MenuBarItemConfig) -> Binding<Bool> {
+        Binding(get: { item.showsCaption },
+                set: { shows in mutate(item) { $0.showsCaption = shows } })
     }
 
     /// The item the store would refuse to disable, or nil when more than one is on.

--- a/Sources/AirStatUI/Settings/SettingsSupport.swift
+++ b/Sources/AirStatUI/Settings/SettingsSupport.swift
@@ -55,7 +55,7 @@ public enum SettingsTab: String, CaseIterable, Identifiable, Sendable {
     ///
     /// The render harness constructs `SettingsRootView` with no arguments, so the
     /// only way to inspect a pane other than the first is to let the environment
-    /// choose it. `AIRSTAT_SETTINGS_TAB=overlay AirStat --render settings` renders
+    /// choose it. `AIRSTAT_SETTINGS_TAB=overlay AirStats --render settings` renders
     /// the overlay pane; unset, it behaves exactly as the real window does.
     static var renderDefault: SettingsTab {
         guard let raw = ProcessInfo.processInfo.environment["AIRSTAT_SETTINGS_TAB"],
@@ -487,12 +487,43 @@ struct MenuBarPreview: NSViewRepresentable {
     }
 }
 
+/// Measures the readouts with the same view that draws them, so the strip can size a
+/// slot for them and tell when the bar runs past its edge. A throwaway view rather
+/// than a reimplementation of the layout, for the reason `MenuBarPreview` exists:
+/// a second measurement would drift from the first.
+@MainActor
+private enum MenuBarPreviewMetrics {
+    private static let prototype = MenuBarContentView(frame: .zero)
+
+    static func size(of model: MenuBarRenderModel) -> CGSize {
+        prototype.update(with: model)
+        return prototype.intrinsicContentSize
+    }
+}
+
 /// Presents the preview on a surface that reads as a menu bar, because contrast in
 /// the menu bar is the thing being judged and a preview on a form background would
 /// misrepresent it.
+///
+/// The strip is a viewport onto a bar wider than itself. A settings window 760 points
+/// across cannot show a screen's worth of menu bar — all sixteen readouts measure more
+/// than twice the room this row has — so they get a slot bounded by what is left
+/// beside the clock and scroll inside it. Letting them take their natural width is
+/// what pushed the sidebar and the pane out of the window frame; dropping the overflow
+/// instead of scrolling it would be a lie, since those readouts do fit in a real bar.
 struct MenuBarPreviewStrip: View {
     let model: MenuBarRenderModel
     let isEmpty: Bool
+
+    /// Width the readouts were actually given. Held against their natural width it is
+    /// the only thing that says whether the bar continues past the slot. Unbounded
+    /// until the first measurement lands, because starting at zero means every open
+    /// of the pane flashes the marker for a frame.
+    @State private var slotWidth: CGFloat = .infinity
+
+    private var naturalSize: CGSize { MenuBarPreviewMetrics.size(of: model) }
+
+    private var isTruncated: Bool { naturalSize.width - slotWidth > 0.5 }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -501,8 +532,15 @@ struct MenuBarPreviewStrip: View {
                 Text("No readouts are enabled.")
                     .font(.callout)
                     .foregroundStyle(Design.Palette.secondaryText)
+                    .lineLimit(1)
             } else {
-                MenuBarPreview(model: model)
+                readouts
+                if isTruncated {
+                    Image(systemName: "ellipsis")
+                        .foregroundStyle(Design.Palette.tertiaryText)
+                        .padding(.leading, Design.Space.s)
+                        .accessibilityHidden(true)
+                }
             }
             Image(systemName: "wifi").foregroundStyle(Design.Palette.tertiaryText)
                 .padding(.leading, Design.Space.l)
@@ -510,6 +548,8 @@ struct MenuBarPreviewStrip: View {
                 .padding(.leading, Design.Space.m)
             Text(Date(), format: .dateTime.weekday(.abbreviated).hour().minute())
                 .foregroundStyle(Design.Palette.tertiaryText)
+                .lineLimit(1)
+                .fixedSize()
                 .padding(.leading, Design.Space.l)
             Spacer(minLength: Design.Space.xl)
         }
@@ -520,6 +560,30 @@ struct MenuBarPreviewStrip: View {
                                                                   style: .continuous))
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Menu bar preview")
-        .accessibilityValue(isEmpty ? "No readouts enabled" : model.accessibilityDescription)
+        .accessibilityValue(accessibilityValue)
+    }
+
+    /// The slot is capped at the readouts' natural width so a short bar still sits
+    /// centred, and floors at nothing so the window's width always wins.
+    private var readouts: some View {
+        ScrollView(.horizontal) {
+            MenuBarPreview(model: model)
+        }
+        .frame(maxWidth: naturalSize.width)
+        .frame(height: naturalSize.height)
+        .background {
+            GeometryReader { proxy in
+                Color.clear
+                    .onChange(of: proxy.size.width, initial: true) { _, width in
+                        slotWidth = width
+                    }
+            }
+        }
+    }
+
+    private var accessibilityValue: String {
+        if isEmpty { return "No readouts enabled" }
+        guard isTruncated else { return model.accessibilityDescription }
+        return model.accessibilityDescription + ". Scroll the preview to see the rest"
     }
 }

--- a/Sources/AirStatUI/Settings/SettingsWindowController.swift
+++ b/Sources/AirStatUI/Settings/SettingsWindowController.swift
@@ -228,10 +228,15 @@ struct SettingsRootView: View {
                                                            style: .continuous))
                     }
                     .buttonStyle(.plain)
-                    // One element per row rather than a container holding an image
-                    // and a label, so VoiceOver announces "General, selected,
+                    // A Button already publishes its label subtree as one element, so
+                    // naming it here is all it takes to announce "General, selected,
                     // button" instead of walking into the row's decoration.
-                    .accessibilityElement(children: .ignore)
+                    //
+                    // Not `.accessibilityElement(children: .ignore)`, which reads the
+                    // same but builds a replacement element in place of the button and
+                    // so carries no press action. The rows still announced themselves
+                    // as buttons, because a trait is a description and not an action,
+                    // and nothing happened when VoiceOver activated them.
                     .accessibilityLabel(item.label)
                     .accessibilityAddTraits(item == tab ? [.isSelected, .isButton] : .isButton)
                     .accessibilityHint("Show \(item.label) settings")

--- a/Sources/AirStatUI/Support/GlobalHotKeyCenter.swift
+++ b/Sources/AirStatUI/Support/GlobalHotKeyCenter.swift
@@ -1,0 +1,253 @@
+import AppKit
+import Carbon.HIToolbox
+import AirStatKit
+
+/// Claims the user's recorded shortcuts system-wide and reports which action fired.
+///
+/// Registration goes through Carbon's `RegisterEventHotKey` rather than a `CGEvent`
+/// tap. A tap would have to be told about every keystroke on the system, which needs
+/// Accessibility trust, and AirStat has no other reason to ask the user for that
+/// permission. Carbon hands back only the chords that were asked for and needs no
+/// grant at all.
+@MainActor
+public final class GlobalHotKeyCenter {
+
+    /// Called on the main thread when a registered chord is pressed.
+    public var onAction: ((ShortcutAction) -> Void)?
+
+    private let settings: SettingsStore
+
+    private var registrations: [ShortcutAction: EventHotKeyRef] = [:]
+    /// What each live registration was made from, so a settings change can be reduced
+    /// to the actions that actually changed instead of tearing all three down.
+    private var registered: [ShortcutAction: AirStatKit.KeyboardShortcut] = [:]
+
+    private var eventHandler: EventHandlerRef?
+    private var observationTask: Task<Void, Never>?
+    private var activationObserver: (any NSObjectProtocol)?
+    private var pendingReport: String?
+
+    /// Distinguishes our hot key identifiers from any other Carbon client's in the
+    /// same process. "ASKY". Nonisolated because the C event handler reads it before
+    /// it has established that it is on the main actor.
+    nonisolated static let signature = OSType(0x4153_4B59)
+
+    /// The C event handler cannot capture, so it reaches the live centre through this.
+    static weak var active: GlobalHotKeyCenter?
+
+    public init(settings: SettingsStore) {
+        self.settings = settings
+    }
+
+    /// Hot keys held by the system on our behalf right now. A registration left behind
+    /// is as silent as the stale event monitors `PanelController` guards against, and
+    /// worse: it keeps a chord away from every other app. Exposed to be checked rather
+    /// than reasoned about.
+    public var activeRegistrationCount: Int { registrations.count }
+
+    // MARK: Lifecycle
+
+    public func start() {
+        GlobalHotKeyCenter.active = self
+        installEventHandler()
+        reconcile()
+        beginObservingSettings()
+    }
+
+    public func stop() {
+        observationTask?.cancel()
+        observationTask = nil
+        if let activationObserver {
+            NotificationCenter.default.removeObserver(activationObserver)
+        }
+        activationObserver = nil
+        for (_, ref) in registrations { UnregisterEventHotKey(ref) }
+        registrations.removeAll()
+        registered.removeAll()
+        if let eventHandler { RemoveEventHandler(eventHandler) }
+        eventHandler = nil
+        if GlobalHotKeyCenter.active === self { GlobalHotKeyCenter.active = nil }
+        WindowLog.log("hot keys stopped count=\(activeRegistrationCount)")
+    }
+
+    private func installEventHandler() {
+        guard eventHandler == nil else { return }
+        var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                                 eventKind: UInt32(kEventHotKeyPressed))
+        InstallEventHandler(GetApplicationEventTarget(),
+                            globalHotKeyEventHandler,
+                            1, &spec, nil, &eventHandler)
+    }
+
+    // MARK: Registration
+
+    private func reconcile() {
+        let desired = desiredBindings()
+        for action in ShortcutAction.allCases {
+            guard registered[action] != desired[action] else { continue }
+            unregister(action)
+            if let shortcut = desired[action] { register(shortcut, for: action) }
+        }
+        presentPendingReport()
+    }
+
+    /// The bindings that should hold a registration, after dropping the ones that
+    /// cannot have one.
+    ///
+    /// Two actions assigned the same chord are left to the Shortcut Conflicts warning
+    /// in Settings: Carbon would reject the second as already taken, and treating that
+    /// as unavailable would silently delete a binding the user has already been told
+    /// about and may be about to fix.
+    private func desiredBindings() -> [ShortcutAction: AirStatKit.KeyboardShortcut] {
+        var result: [ShortcutAction: AirStatKit.KeyboardShortcut] = [:]
+        var claimed: Set<Combination> = []
+        for action in ShortcutAction.allCases {
+            guard let shortcut = settings.settings.shortcuts.bindings[action],
+                  shortcut.isGloballyRegisterable,
+                  claimed.insert(Combination(shortcut)).inserted else { continue }
+            result[action] = shortcut
+        }
+        return result
+    }
+
+    private func register(_ shortcut: AirStatKit.KeyboardShortcut, for action: ShortcutAction) {
+        var ref: EventHotKeyRef?
+        let identifier = EventHotKeyID(signature: GlobalHotKeyCenter.signature,
+                                       id: action.hotKeyIdentifier)
+        let status = RegisterEventHotKey(shortcut.carbonKeyCode,
+                                         shortcut.carbonModifierFlags,
+                                         identifier,
+                                         GetApplicationEventTarget(),
+                                         0,
+                                         &ref)
+        guard status == noErr, let ref else {
+            WindowLog.log("hot key rejected action=\(action.rawValue) "
+                + "chord=\(ShortcutDisplay.string(for: shortcut)) status=\(status)")
+            reportUnavailable(shortcut, for: action)
+            return
+        }
+        registrations[action] = ref
+        registered[action] = shortcut
+        WindowLog.log("hot key registered action=\(action.rawValue) "
+            + "chord=\(ShortcutDisplay.string(for: shortcut)) "
+            + "keyCode=\(shortcut.carbonKeyCode) modifiers=\(shortcut.carbonModifierFlags) "
+            + "count=\(activeRegistrationCount)")
+    }
+
+    private func unregister(_ action: ShortcutAction) {
+        guard let ref = registrations[action] else { return }
+        UnregisterEventHotKey(ref)
+        registrations[action] = nil
+        registered[action] = nil
+        WindowLog.log("hot key unregistered action=\(action.rawValue) count=\(activeRegistrationCount)")
+    }
+
+    /// Drop a chord the system would not give us and say so. Keeping it would leave
+    /// the recorder in Settings displaying a shortcut that can never fire, which is a
+    /// worse outcome than losing a binding the user has to record again anyway.
+    private func reportUnavailable(_ shortcut: AirStatKit.KeyboardShortcut, for action: ShortcutAction) {
+        let display = ShortcutDisplay.string(for: shortcut)
+        pendingReport = "\(display) is already claimed by macOS or another app, "
+            + "so it was not assigned to \(action.label). Record a different combination."
+        settings.update { $0.shortcuts.bindings[action] = nil }
+    }
+
+    private func presentPendingReport() {
+        guard let message = pendingReport else { return }
+        // At launch AirStat is not frontmost, and an alert put up then would sit behind
+        // whatever the user is actually doing. Hold it until they come back to the app,
+        // which is also where the recorder they need is.
+        guard NSApp.isActive else {
+            observeActivation()
+            return
+        }
+        pendingReport = nil
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Shortcut Unavailable"
+        alert.informativeText = message
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func observeActivation() {
+        guard activationObserver == nil else { return }
+        activationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil, queue: .main) { [weak self] _ in
+                MainActor.assumeIsolated { self?.presentPendingReport() }
+        }
+    }
+
+    // MARK: Dispatch
+
+    fileprivate func fire(_ identifier: UInt32) {
+        guard let action = ShortcutAction.action(forHotKeyIdentifier: identifier) else { return }
+        WindowLog.log("hot key fired action=\(action.rawValue) appActive=\(NSApp.isActive)")
+        onAction?(action)
+    }
+
+    // MARK: Settings observation
+
+    /// Recording a shortcut has to take effect without a relaunch, and the recorder
+    /// writes straight to the store, so the registrations are driven from the store
+    /// the way the overlay drives its window configuration.
+    private func beginObservingSettings() {
+        observationTask?.cancel()
+        observationTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await GlobalHotKeyCenter.awaitChange { _ = self.settings.revision }
+                guard !Task.isCancelled else { return }
+                // `onChange` fires before the new value is stored; yield so the write
+                // has landed before it is read back.
+                await Task.yield()
+                self.reconcile()
+            }
+        }
+    }
+
+    @MainActor
+    private static func awaitChange(_ track: @escaping () -> Void) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            withObservationTracking { track() } onChange: { continuation.resume() }
+        }
+    }
+
+    /// A chord identified by what Carbon is asked to claim, so two bindings collide
+    /// here exactly when Carbon would refuse the second one.
+    private struct Combination: Hashable {
+        let keyCode: UInt32
+        let modifiers: UInt32
+
+        init(_ shortcut: AirStatKit.KeyboardShortcut) {
+            keyCode = shortcut.carbonKeyCode
+            modifiers = shortcut.carbonModifierFlags
+        }
+    }
+}
+
+/// Top level and capturing nothing, which is what lets Swift hand it to Carbon as a
+/// plain C function pointer.
+private func globalHotKeyEventHandler(_ callRef: EventHandlerCallRef?,
+                                      _ event: EventRef?,
+                                      _ userData: UnsafeMutableRawPointer?) -> OSStatus {
+    guard let event else { return OSStatus(eventNotHandledErr) }
+    var identifier = EventHotKeyID()
+    let status = GetEventParameter(event,
+                                   EventParamName(kEventParamDirectObject),
+                                   EventParamType(typeEventHotKeyID),
+                                   nil,
+                                   MemoryLayout<EventHotKeyID>.size,
+                                   nil,
+                                   &identifier)
+    guard status == noErr, identifier.signature == GlobalHotKeyCenter.signature else {
+        return OSStatus(eventNotHandledErr)
+    }
+    // Carbon dispatches hot keys on the main thread's run loop, so the work the
+    // handler triggers is already where it needs to be.
+    MainActor.assumeIsolated {
+        GlobalHotKeyCenter.active?.fire(identifier.id)
+    }
+    return noErr
+}

--- a/Sources/AirStatUI/Support/ThresholdEvaluator.swift
+++ b/Sources/AirStatUI/Support/ThresholdEvaluator.swift
@@ -1,0 +1,177 @@
+import Foundation
+import AirStatKit
+
+/// A rule that has earned a notification.
+struct ThresholdAlert: Equatable {
+    let ruleID: UUID
+    let metric: ThresholdMetric
+    let value: Double
+    let threshold: Double
+}
+
+/// The decision half of threshold monitoring: given the rules, the current readings
+/// and the time, which rules should notify.
+///
+/// Held apart from delivery so the sustained-duration and cooldown bookkeeping can be
+/// tested without a notification centre, and so the monitor is left holding only the
+/// parts that need one.
+struct ThresholdEvaluator {
+
+    private struct RuleState {
+        var breachBegan: Date?
+        var notifiedAt: Date?
+        /// True once this unbroken run of the condition has produced an alert.
+        var alertedThisEpisode = false
+    }
+
+    private var states: [UUID: RuleState] = [:]
+
+    /// Rules currently carrying breach or cooldown state. Exposed so a test can show
+    /// that state for a rule the user switched off is dropped rather than accumulated.
+    var trackedRuleCount: Int { states.count }
+
+    mutating func reset() { states.removeAll() }
+
+    /// Advances every rule's clock by one sample and returns the rules that fire.
+    ///
+    /// `rules` is the set already cleared for delivery: master switch on, rule on,
+    /// metric measurable here. State for anything absent from it is discarded, so a
+    /// rule the user turns off does not come back mid-cooldown.
+    mutating func alerts(for rules: [ThresholdRule],
+                         readings: [ThresholdMetric: Double],
+                         now: Date) -> [ThresholdAlert] {
+        var alerts: [ThresholdAlert] = []
+        var surviving: [UUID: RuleState] = [:]
+
+        for rule in rules {
+            var state = states[rule.id] ?? RuleState()
+            defer { surviving[rule.id] = state }
+
+            // A missing reading is not evidence the condition ended, but it is not
+            // evidence it held either, so the sustained clock restarts rather than
+            // crediting time nobody measured.
+            guard let value = readings[rule.metric],
+                  rule.metric.isBreached(by: value, threshold: rule.threshold) else {
+                state.breachBegan = nil
+                state.alertedThisEpisode = false
+                continue
+            }
+
+            let began = state.breachBegan ?? now
+            state.breachBegan = began
+            guard now.timeIntervalSince(began) >= rule.sustainedFor else { continue }
+            if rule.metric.notifiesOncePerEpisode && state.alertedThisEpisode { continue }
+            if let notifiedAt = state.notifiedAt, now.timeIntervalSince(notifiedAt) < rule.cooldown { continue }
+
+            state.notifiedAt = now
+            state.alertedThisEpisode = true
+            alerts.append(ThresholdAlert(ruleID: rule.id, metric: rule.metric,
+                                         value: value, threshold: rule.threshold))
+        }
+
+        states = surviving
+        return alerts
+    }
+
+    /// Every watchable metric read out of a snapshot in the units the Notifications
+    /// pane presents, so a rule compares against the number the user typed.
+    ///
+    /// A metric this Mac cannot measure is simply absent rather than zero.
+    static func readings(from snapshot: SystemSnapshot) -> [ThresholdMetric: Double] {
+        var readings: [ThresholdMetric: Double] = [:]
+
+        if let cpu = snapshot.cpu.value {
+            readings[.cpuUsage] = cpu.total.busy * 100
+        }
+        if let memory = snapshot.memory.value {
+            readings[.memoryPressure] = memory.pressureFraction * 100
+        }
+        if let root = snapshot.disk.value?.rootVolume {
+            // `availableBytes` is what the disk module calls free, and decimal GB is
+            // the unit macOS states disk capacity in, which is what the rule's "GB"
+            // suffix will mean to whoever typed the number.
+            readings[.diskFree] = Double(root.availableBytes) / 1_000_000_000
+        }
+        if let power = snapshot.power.value, let percentage = power.percentage {
+            // Split by charge state: a low-battery warning is noise once the machine
+            // is on the charger, and a full-battery alert has nothing to say to a
+            // battery that is discharging through 100%.
+            if power.isPluggedIn {
+                readings[.batteryFull] = percentage
+            } else {
+                readings[.batteryLow] = percentage
+            }
+        }
+        if let thermal = snapshot.thermal.value {
+            if let cpuCelsius = thermal.cpuCelsius { readings[.cpuTemperature] = cpuCelsius }
+            readings[.thermalPressure] = Double(thermal.pressure.rawValue)
+        }
+
+        return readings
+    }
+}
+
+extension ThresholdMetric {
+
+    /// Direction is per metric, not uniform: free disk space and a draining battery
+    /// are alarming as they fall, everything else as it climbs.
+    var firesWhenBelow: Bool {
+        switch self {
+        case .diskFree, .batteryLow: return true
+        case .cpuUsage, .memoryPressure, .batteryFull, .cpuTemperature, .thermalPressure: return false
+        }
+    }
+
+    func isBreached(by value: Double, threshold: Double) -> Bool {
+        firesWhenBelow ? value <= threshold : value >= threshold
+    }
+
+    /// Reaching a full charge is an event, not a condition. A Mac left on the charger
+    /// sits at 100% for hours, and repeating on every cooldown would make the rule
+    /// unusable, so it waits for the battery to leave the threshold first.
+    var notifiesOncePerEpisode: Bool { self == .batteryFull }
+}
+
+extension ThresholdAlert {
+
+    var title: String {
+        switch metric {
+        case .cpuUsage: return "CPU usage is high"
+        case .memoryPressure: return "Memory pressure is high"
+        case .diskFree: return "Startup disk is running out of space"
+        case .batteryLow: return "Battery is low"
+        case .batteryFull: return "Battery is charged"
+        case .cpuTemperature: return "CPU is running hot"
+        case .thermalPressure: return "This Mac is under thermal pressure"
+        }
+    }
+
+    var body: String {
+        switch metric {
+        case .cpuUsage:
+            return "CPU is at \(percent(value)), above your \(percent(threshold)) threshold."
+        case .memoryPressure:
+            return "Memory pressure is at \(percent(value)), above your \(percent(threshold)) threshold."
+        case .diskFree:
+            return "\(gigabytes(value)) free on the startup disk, below your \(gigabytes(threshold)) threshold."
+        case .batteryLow:
+            return "Battery is at \(percent(value)), below your \(percent(threshold)) threshold."
+        case .batteryFull:
+            return "Battery is at \(percent(value)). You can unplug."
+        case .cpuTemperature:
+            return "CPU is at \(degrees(value)), above your \(degrees(threshold)) threshold."
+        case .thermalPressure:
+            return "Thermal pressure is \(level(value)), at or past your \(level(threshold)) threshold."
+        }
+    }
+
+    private func percent(_ value: Double) -> String { "\(Int(value.rounded()))%" }
+
+    private func gigabytes(_ value: Double) -> String { "\(Int(value.rounded())) GB" }
+
+    private func degrees(_ value: Double) -> String { "\(Int(value.rounded()))°" }
+
+    private func level(_ value: Double) -> String {
+        ThermalPressure(rawValue: Int(value))?.label.lowercased() ?? "\(Int(value))"
+    }
+}

--- a/Sources/AirStatUI/Support/ThresholdMonitor.swift
+++ b/Sources/AirStatUI/Support/ThresholdMonitor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UserNotifications
 import AirStatKit
 
 /// Watches metrics against the user's threshold rules and posts notifications.
@@ -11,12 +12,175 @@ public final class ThresholdMonitor {
     private let engine: MetricsEngine
     private let settings: SettingsStore
 
+    private var observationTask: Task<Void, Never>?
+    private var authorizationTask: Task<Void, Never>?
+    private var evaluator = ThresholdEvaluator()
+    private var authorization: Authorization = .undetermined
+    private var presenter: ForegroundPresenter?
+
+    /// True while the observation loop and any pending authorisation request are
+    /// installed.
+    ///
+    /// Exposed for the same reason `PanelController.activeEventMonitorCount` is: a
+    /// task or a delegate that outlives `stop()` is silent, and nothing looks wrong
+    /// until the app is posting notifications on behalf of a shut-down monitor.
+    public var isRunning: Bool {
+        observationTask != nil || authorizationTask != nil || presenter != nil
+    }
+
+    private enum Authorization {
+        case undetermined
+        case requesting
+        case granted
+        /// Refused by the user, or impossible because the process is not running from
+        /// an app bundle. Both are final for this launch, so nothing asks again.
+        case unavailable
+    }
+
     public init(engine: MetricsEngine, settings: SettingsStore) {
         self.engine = engine
         self.settings = settings
     }
 
-    public func start() {}
+    // MARK: Lifecycle
 
-    public func stop() {}
+    public func start() {
+        guard observationTask == nil else { return }
+        // Observation-driven like the status item rather than a timer of its own: the
+        // rules can only ever change answer when a new snapshot or a new setting lands.
+        observationTask = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await ThresholdMonitor.awaitChange {
+                    _ = self.engine.snapshot
+                    _ = self.settings.revision
+                }
+                guard !Task.isCancelled else { return }
+                await Task.yield()
+                self.evaluate()
+            }
+        }
+        evaluate()
+    }
+
+    public func stop() {
+        observationTask?.cancel()
+        observationTask = nil
+        authorizationTask?.cancel()
+        authorizationTask = nil
+        if let presenter {
+            // The delegate is a process-wide slot on a shared singleton, so this clears
+            // it only while it still holds *our* presenter. Nothing else in the app
+            // wants that slot today, and a teardown that silently unhooks whoever does
+            // want it next is the kind of thing nobody finds for months.
+            let center = UNUserNotificationCenter.current()
+            if center.delegate === presenter { center.delegate = nil }
+            self.presenter = nil
+        }
+        evaluator.reset()
+        authorization = .undetermined
+    }
+
+    @MainActor
+    private static func awaitChange(_ track: @escaping () -> Void) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            withObservationTracking { track() } onChange: { continuation.resume() }
+        }
+    }
+
+    // MARK: Evaluation
+
+    private func evaluate() {
+        let notifications = settings.settings.notifications
+        guard notifications.isEnabled else {
+            evaluator.reset()
+            return
+        }
+        // Nothing is measured until there is somewhere to send the answer. Denial is
+        // terminal, so a refused prompt costs one check per sample and no more.
+        guard authorization == .granted else {
+            requestAuthorizationIfNeeded()
+            return
+        }
+
+        // A rule for a metric this Mac cannot measure could never fire honestly, and
+        // the pane already tells the user so.
+        let availability = MetricAvailability(snapshot: engine.snapshot)
+        let rules = notifications.enabledRules.filter { availability.note(for: $0.metric) == nil }
+
+        let alerts = evaluator.alerts(for: rules,
+                                      readings: ThresholdEvaluator.readings(from: engine.snapshot),
+                                      now: Date())
+        for alert in alerts { deliver(alert) }
+    }
+
+    // MARK: Authorisation
+
+    /// Asks the first time the user actually switches notifications on, never at
+    /// launch. A menu bar utility that demands permission on first run is asking for
+    /// something the user has not opted into yet.
+    private func requestAuthorizationIfNeeded() {
+        guard authorization == .undetermined else { return }
+        guard Bundle.main.bundleIdentifier != nil else {
+            // `UNUserNotificationCenter.current()` traps outside an app bundle, which
+            // is how the render and probe CLIs run out of `.build`.
+            authorization = .unavailable
+            return
+        }
+
+        authorization = .requesting
+        let center = UNUserNotificationCenter.current()
+        authorizationTask = Task { @MainActor [weak self] in
+            var granted = false
+            do {
+                granted = try await center.requestAuthorization(options: [.alert, .sound])
+            } catch {
+                // The failure mode of this whole feature is silence, so the one thing
+                // that must never be swallowed is why nothing is arriving.
+                WindowLog.log("notification authorisation failed: \(error)")
+            }
+            guard let self, !Task.isCancelled, self.authorization == .requesting else { return }
+            self.authorizationTask = nil
+            self.authorization = granted ? .granted : .unavailable
+            if granted {
+                let presenter = ForegroundPresenter()
+                center.delegate = presenter
+                self.presenter = presenter
+            }
+            WindowLog.log("notification authorisation \(granted ? "granted" : "refused")")
+        }
+    }
+
+    // MARK: Delivery
+
+    private func deliver(_ alert: ThresholdAlert) {
+        let content = UNMutableNotificationContent()
+        content.title = alert.title
+        content.body = alert.body
+        content.sound = .default
+
+        // One identifier per rule, so a rule that fires again after its cooldown
+        // replaces its own stale banner instead of stacking a column of the same
+        // warning in Notification Centre.
+        let request = UNNotificationRequest(identifier: "threshold.\(alert.ruleID.uuidString)",
+                                            content: content,
+                                            trigger: nil)
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                WindowLog.log("notification delivery failed: \(error.localizedDescription)")
+            }
+        }
+        WindowLog.log("notification posted metric=\(alert.metric.rawValue) value=\(alert.value) threshold=\(alert.threshold)")
+    }
+}
+
+/// macOS suppresses banners for the app that is currently frontmost. AirStats is
+/// frontmost whenever its settings window has focus, which is exactly where a user
+/// goes to set these rules up, so present them anyway.
+private final class ForegroundPresenter: NSObject, UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+        completionHandler([.banner, .sound])
+    }
 }

--- a/Sources/AirStats/AppCoordinator.swift
+++ b/Sources/AirStats/AppCoordinator.swift
@@ -16,8 +16,13 @@ final class AppCoordinator {
     private let overlay: OverlayController
     private let settingsWindow: SettingsWindowController
     private let thresholdMonitor: ThresholdMonitor
+    private let hotKeys: GlobalHotKeyCenter
 
     private var observers: [any NSObjectProtocol] = []
+    /// Where the panel is currently hung. Kept here because with one status item per
+    /// readout, "toggle" has a third case: the click came from a different item than
+    /// the one the panel is under.
+    private var panelAnchor: NSRect?
 
     init() {
         let store = SettingsStore()
@@ -29,6 +34,7 @@ final class AppCoordinator {
         self.overlay = OverlayController(engine: engine, settings: store)
         self.settingsWindow = SettingsWindowController(engine: engine, settings: store)
         self.thresholdMonitor = ThresholdMonitor(engine: engine, settings: store)
+        self.hotKeys = GlobalHotKeyCenter(settings: store)
     }
 
     // MARK: Lifecycle
@@ -50,9 +56,22 @@ final class AppCoordinator {
             self?.engine.setOverlayVisible(visible)
         }
 
+        // A hot key must do exactly what the equivalent menu item does, including
+        // leaving the frontmost app alone: the panel is worth having precisely because
+        // it can be summoned over another app without interrupting it.
+        hotKeys.onAction = { [weak self] action in
+            guard let self else { return }
+            switch action {
+            case .togglePanel: self.togglePanel()
+            case .toggleOverlay: self.toggleOverlay()
+            case .openSettings: self.showSettings()
+            }
+        }
+
         statusItem.install()
         engine.start()
         thresholdMonitor.start()
+        hotKeys.start()
         overlay.syncWithSettings()
 
         registerSystemObservers()
@@ -66,6 +85,7 @@ final class AppCoordinator {
             NotificationCenter.default.removeObserver(observer)
         }
         observers.removeAll()
+        hotKeys.stop()
         thresholdMonitor.stop()
         engine.stop()
         statusItem.remove()
@@ -76,16 +96,32 @@ final class AppCoordinator {
     // MARK: Actions
 
     private func togglePanel() {
-        if panel.isVisible {
-            panel.hide()
-        } else {
-            panel.show(anchoredTo: statusItem.anchorRect, on: statusItem.anchorScreen)
+        let anchor = statusItem.anchorRect
+        guard panel.isVisible else {
+            panelAnchor = anchor
+            panel.show(anchoredTo: anchor, on: statusItem.anchorScreen)
+            return
         }
+        // Clicking a second readout's item moves the panel under it. Dismissing there
+        // would read as the click having missed: the user pointed at a different item
+        // and got nothing.
+        if let anchor, let panelAnchor, anchor != panelAnchor {
+            self.panelAnchor = anchor
+            panel.reanchor(to: anchor, on: statusItem.anchorScreen)
+            return
+        }
+        panel.hide()
+        panelAnchor = nil
     }
 
     private func showSettings() {
         panel.hide()
         settingsWindow.show()
+    }
+
+    private func toggleOverlay() {
+        settingsStore.update { $0.overlay.isEnabled.toggle() }
+        overlay.syncWithSettings()
     }
 
     private func showContextMenu() {
@@ -103,10 +139,7 @@ final class AppCoordinator {
 
     @objc private func menuShowSettings() { showSettings() }
 
-    @objc private func menuToggleOverlay() {
-        settingsStore.update { $0.overlay.isEnabled.toggle() }
-        overlay.syncWithSettings()
-    }
+    @objc private func menuToggleOverlay() { toggleOverlay() }
 
     // MARK: System observers
 
@@ -159,7 +192,8 @@ final class AppCoordinator {
                     guard let self else { return }
                     self.overlay.screenConfigurationChanged()
                     if self.panel.isVisible {
-                        self.panel.reanchor(to: self.statusItem.anchorRect,
+                        self.panelAnchor = self.statusItem.anchorRect
+                        self.panel.reanchor(to: self.panelAnchor,
                                             on: self.statusItem.anchorScreen)
                     }
                 }

--- a/Tests/AirStatKitTests/HotKeyTranslationTests.swift
+++ b/Tests/AirStatKitTests/HotKeyTranslationTests.swift
@@ -1,0 +1,86 @@
+import Testing
+import AppKit
+import Carbon.HIToolbox
+@testable import AirStatKit
+
+@Suite("Recorded shortcuts translate into what RegisterEventHotKey takes")
+struct HotKeyTranslationTests {
+
+    private func shortcut(_ keyCode: UInt16, _ flags: NSEvent.ModifierFlags) -> KeyboardShortcut {
+        KeyboardShortcut(keyCode: keyCode, modifierFlags: flags.rawValue, characters: "")
+    }
+
+    @Test("each modifier maps onto its Carbon bit")
+    func modifiersMapIndividually() {
+        #expect(shortcut(35, .command).carbonModifierFlags == UInt32(cmdKey))
+        #expect(shortcut(35, .option).carbonModifierFlags == UInt32(optionKey))
+        #expect(shortcut(35, .control).carbonModifierFlags == UInt32(controlKey))
+        #expect(shortcut(35, .shift).carbonModifierFlags == UInt32(shiftKey))
+    }
+
+    @Test("a chord combines the bits rather than picking one")
+    func modifiersCombine() {
+        let combined = shortcut(35, [.command, .shift, .option]).carbonModifierFlags
+        #expect(combined == UInt32(cmdKey) | UInt32(shiftKey) | UInt32(optionKey))
+    }
+
+    @Test("no modifiers means no Carbon bits")
+    func bareKeyHasNoModifiers() {
+        #expect(shortcut(35, []).carbonModifierFlags == 0)
+    }
+
+    @Test("keyboard state that is not part of the chord is dropped")
+    func stateFlagsAreDropped() {
+        // Caps Lock on while recording ⌘P must not produce a hot key that needs Caps
+        // Lock to fire.
+        let recorded = shortcut(35, [.command, .capsLock, .function, .numericPad])
+        #expect(recorded.carbonModifierFlags == UInt32(cmdKey))
+    }
+
+    @Test("the key code passes through unchanged")
+    func keyCodePassesThrough() {
+        #expect(shortcut(35, .command).carbonKeyCode == 35)
+        #expect(shortcut(UInt16(kVK_Escape), .command).carbonKeyCode == UInt32(kVK_Escape))
+    }
+
+    @Test("only chords with ⌘, ⌥ or ⌃ may be claimed system-wide")
+    func registerabilityMatchesTheRecorder() {
+        #expect(shortcut(35, .command).isGloballyRegisterable)
+        #expect(shortcut(35, .option).isGloballyRegisterable)
+        #expect(shortcut(35, .control).isGloballyRegisterable)
+        // Shift plus a key is how you type a capital letter; claiming it would eat the
+        // keystroke everywhere.
+        #expect(!shortcut(35, .shift).isGloballyRegisterable)
+        #expect(!shortcut(35, []).isGloballyRegisterable)
+        #expect(!shortcut(35, .capsLock).isGloballyRegisterable)
+    }
+
+    @Test("every action has its own hot key identifier")
+    func identifiersAreUnique() {
+        let identifiers = ShortcutAction.allCases.map(\.hotKeyIdentifier)
+        #expect(Set(identifiers).count == ShortcutAction.allCases.count)
+        // Zero is what an uninitialised `EventHotKeyID` carries, so no action may use it.
+        #expect(!identifiers.contains(0))
+    }
+
+    @Test("the identifier Carbon hands back resolves to the action that was registered")
+    func identifiersRoundTrip() {
+        for action in ShortcutAction.allCases {
+            #expect(ShortcutAction.action(forHotKeyIdentifier: action.hotKeyIdentifier) == action)
+        }
+        #expect(ShortcutAction.action(forHotKeyIdentifier: 0) == nil)
+        #expect(ShortcutAction.action(forHotKeyIdentifier: 99) == nil)
+    }
+
+    @Test("a hand-edited settings file cannot smuggle in an unregisterable binding")
+    func decodedBindingsAreChecked() throws {
+        // A dictionary keyed by an enum encodes as a flat key, value array, which is
+        // also the shape on disk.
+        let json = """
+        {"shortcuts":{"bindings":["togglePanel",{"keyCode":35,"modifierFlags":0,"characters":"p"}]}}
+        """
+        let settings = try JSONDecoder().decode(Settings.self, from: Data(json.utf8))
+        let binding = try #require(settings.shortcuts.bindings[.togglePanel])
+        #expect(!binding.isGloballyRegisterable)
+    }
+}

--- a/Tests/AirStatKitTests/MenuBarItemLayoutTests.swift
+++ b/Tests/AirStatKitTests/MenuBarItemLayoutTests.swift
@@ -1,0 +1,139 @@
+import Testing
+import Foundation
+@testable import AirStatKit
+@testable import AirStatUI
+
+@Suite("The combine switch decides how many status items the bar gets")
+struct MenuBarItemLayoutTests {
+
+    private let cpu = MenuBarItemConfig(metric: .cpuUsage, style: .text)
+    private let memory = MenuBarItemConfig(metric: .memoryUsage, style: .text)
+    private let gpu = MenuBarItemConfig(metric: .gpuUsage, style: .text)
+
+    @Test("combined means one item, however many readouts are enabled")
+    func combinedIsOneItem() {
+        let settings = MenuBarSettings(items: [cpu, memory, gpu], usesCombinedItem: true)
+        #expect(MenuBarItemLayout(settings: settings) == .combined)
+    }
+
+    @Test("separate means one item per enabled readout, in the configured order")
+    func separateFollowsConfiguredOrder() {
+        var disabled = gpu
+        disabled.isEnabled = false
+        let settings = MenuBarSettings(items: [memory, disabled, cpu], usesCombinedItem: false)
+        #expect(MenuBarItemLayout(settings: settings) == .separate([memory.id, cpu.id]))
+    }
+
+    /// The layout is the whole of what the controller compares, so a switch flip has to
+    /// show up here or nothing rebuilds.
+    @Test("flipping the switch changes the layout either way")
+    func flippingChangesLayout() {
+        let items = [cpu, memory]
+        let combined = MenuBarItemLayout(settings: MenuBarSettings(items: items, usesCombinedItem: true))
+        let separate = MenuBarItemLayout(settings: MenuBarSettings(items: items, usesCombinedItem: false))
+        #expect(combined != separate)
+    }
+
+    @Test("reordering the readouts changes the layout")
+    func reorderingChangesLayout() {
+        let forwards = MenuBarItemLayout(settings: MenuBarSettings(items: [cpu, memory],
+                                                                   usesCombinedItem: false))
+        let backwards = MenuBarItemLayout(settings: MenuBarSettings(items: [memory, cpu],
+                                                                    usesCombinedItem: false))
+        #expect(forwards != backwards)
+    }
+
+    /// Separate items with nothing to draw would leave the menu bar empty and the app
+    /// with no click target at all.
+    @Test("nothing enabled falls back to the combined item")
+    func emptyFallsBackToCombined() {
+        var off = cpu
+        off.isEnabled = false
+        let settings = MenuBarSettings(items: [off], usesCombinedItem: false)
+        #expect(MenuBarItemLayout(settings: settings) == .combined)
+    }
+}
+
+@MainActor
+@Suite("Separate status items keep their place and draw their own readout")
+struct StatusItemControllerLayoutTests {
+
+    @Test("the combined item keeps the autosave name it has always had")
+    func combinedAutosaveNameIsUnchanged() {
+        #expect(StatusItemController.combinedAutosaveName == "AirStatStatusItem")
+    }
+
+    /// Positions are saved against these names, so two readouts must never share one
+    /// and a name must not move when anything else about the readout changes.
+    @Test("each readout gets a distinct, stable autosave name")
+    func autosaveNamesAreDistinctAndStable() {
+        let first = UUID()
+        let second = UUID()
+        #expect(StatusItemController.autosaveName(for: first)
+                != StatusItemController.autosaveName(for: second))
+        #expect(StatusItemController.autosaveName(for: first)
+                == StatusItemController.autosaveName(for: first))
+        #expect(StatusItemController.autosaveName(for: first)
+                != StatusItemController.combinedAutosaveName)
+    }
+
+    @Test("a per-item model carries one readout and the whole bar's drawing settings")
+    func sliceNarrowsToOneReadout() {
+        let items = [MenuBarItemConfig(metric: .cpuUsage, style: .text),
+                     MenuBarItemConfig(metric: .memoryUsage, style: .textAndGraph),
+                     MenuBarItemConfig(metric: .networkThroughput, style: .text)]
+        let model = self.model(items: items)
+        #expect(model.items.count == 3)
+
+        let slice = StatusItemController.slice(model, readout: items[1].id)
+        #expect(slice.items.map(\.id) == [items[1].id])
+        #expect(slice.items.first == model.items[1])
+        #expect(slice.spacing == model.spacing)
+        #expect(slice.usesFixedWidth == model.usesFixedWidth)
+        #expect(slice.usesMonospacedDigits == model.usesMonospacedDigits)
+        #expect(slice.isStale == model.isStale)
+    }
+
+    @Test("the combined item is fed the whole bar")
+    func sliceForCombinedIsEverything() {
+        let model = self.model(items: [MenuBarItemConfig(metric: .cpuUsage, style: .text),
+                                       MenuBarItemConfig(metric: .memoryUsage, style: .text)])
+        #expect(StatusItemController.slice(model, readout: nil) == model)
+    }
+
+    /// VoiceOver reads each item on its own now, so an item must not announce its
+    /// neighbours' numbers.
+    @Test("an item describes only its own readout")
+    func sliceDescribesOnlyItsOwnReadout() {
+        let items = [MenuBarItemConfig(metric: .cpuUsage, style: .text),
+                     MenuBarItemConfig(metric: .memoryUsage, style: .text)]
+        let model = self.model(items: items)
+        let slice = StatusItemController.slice(model, readout: items[0].id)
+        #expect(slice.accessibilityDescription == model.items[0].accessibilityLabel)
+        #expect(!slice.accessibilityDescription.contains("Memory"))
+    }
+
+    /// Each item redraws only when its own model changes, so a slice must not move when
+    /// another readout's value does.
+    @Test("a readout's slice is unchanged by another readout's value")
+    func sliceIgnoresOtherReadouts() {
+        let items = [MenuBarItemConfig(metric: .cpuUsage, style: .text),
+                     MenuBarItemConfig(metric: .memoryUsage, style: .text)]
+        var busier = SnapshotFixtures.nominal
+        busier.memory = .value(SnapshotFixtures.memory(usedFraction: 0.91, pressure: 0.44))
+
+        let before = StatusItemController.slice(model(items: items), readout: items[0].id)
+        let after = StatusItemController.slice(model(items: items, snapshot: busier),
+                                               readout: items[0].id)
+        #expect(before == after)
+    }
+
+    private func model(items: [MenuBarItemConfig],
+                       snapshot: SystemSnapshot = SnapshotFixtures.nominal) -> MenuBarRenderModel {
+        MenuBarRenderModel(snapshot: snapshot,
+                           history: SnapshotFixtures.history(),
+                           settings: Settings(menuBar: MenuBarSettings(items: items,
+                                                                       usesCombinedItem: false)),
+                           isStale: false)
+    }
+}

--- a/Tests/AirStatKitTests/MenuBarPaneBindingTests.swift
+++ b/Tests/AirStatKitTests/MenuBarPaneBindingTests.swift
@@ -1,0 +1,77 @@
+import Testing
+import Foundation
+@testable import AirStatKit
+@testable import AirStatUI
+
+/// A `Picker` in the pane's editing section keeps its binding for the length of a
+/// SwiftUI update pass. Restore Defaults and Import replace `menuBar.items` inside
+/// that pass, so a binding built for the fourth readout is read back when only two
+/// exist. It used to subscript by index there and take the app down with it.
+@MainActor
+@Suite("Menu bar readout bindings outlive the list they were built for")
+struct MenuBarPaneBindingTests {
+
+    private func store() -> SettingsStore {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return SettingsStore(directory: dir, saveDebounce: .milliseconds(1))
+    }
+
+    /// Four readouts, so the last one sits past the end of the two shipped defaults.
+    private func fourReadouts(_ settings: SettingsStore) -> MenuBarItemConfig {
+        settings.update { s in
+            s.menuBar.items = [MenuBarMetric.cpuUsage, .memoryUsage, .diskFree, .networkThroughput]
+                .map { MenuBarItemConfig(metric: $0, style: $0.supportedStyles.first ?? .text) }
+        }
+        return settings.settings.menuBar.items[3]
+    }
+
+    @Test("reading a binding after Restore Defaults returns the captured value")
+    func readSurvivesReset() {
+        let settings = store()
+        let pane = MenuBarPane(settings: settings, engine: nil)
+        let last = fourReadouts(settings)
+
+        let metric = pane.metricBinding(for: last)
+        let style = pane.styleBinding(for: last)
+        let caption = pane.captionBinding(for: last)
+
+        settings.resetSection(.menuBar)
+        #expect(settings.settings.menuBar.items.count < 4)
+
+        #expect(metric.wrappedValue == last.metric)
+        #expect(style.wrappedValue == last.style)
+        #expect(caption.wrappedValue == last.showsCaption)
+    }
+
+    @Test("writing through a binding whose readout is gone changes nothing")
+    func writeAfterResetIsInert() {
+        let settings = store()
+        let pane = MenuBarPane(settings: settings, engine: nil)
+        let last = fourReadouts(settings)
+        let metric = pane.metricBinding(for: last)
+
+        settings.resetSection(.menuBar)
+        let afterReset = settings.settings.menuBar.items
+        metric.wrappedValue = .cpuTemperature
+
+        #expect(settings.settings.menuBar.items == afterReset)
+    }
+
+    @Test("a binding follows its readout across a reorder")
+    func writeFollowsTheItem() {
+        let settings = store()
+        let pane = MenuBarPane(settings: settings, engine: nil)
+        let last = fourReadouts(settings)
+
+        let displaced = settings.settings.menuBar.items[0]
+        settings.update { $0.menuBar.items.reverse() }
+        pane.styleBinding(for: last).wrappedValue = .graph
+
+        // An index-based binding would have written to whatever the reversal left at
+        // index 3, which is the readout that started at index 0.
+        #expect(settings.settings.menuBar.items.first { $0.id == last.id }?.style == .graph)
+        #expect(settings.settings.menuBar.items.first { $0.id == displaced.id }?.style == displaced.style)
+    }
+}

--- a/Tests/AirStatKitTests/MetricsEngineActivityTests.swift
+++ b/Tests/AirStatKitTests/MetricsEngineActivityTests.swift
@@ -1,0 +1,123 @@
+import Testing
+import Foundation
+@testable import AirStatKit
+
+@MainActor
+@Suite("Low Power Mode pausing")
+struct LowPowerPauseTests {
+
+    /// An engine over a throwaway settings directory, so a test never reads or writes
+    /// the real `~/Library/Application Support/AirStat/settings.json`.
+    private func makeEngine(pausesOnLowPower: Bool,
+                            throttlesWhenOccluded: Bool = true) -> (MetricsEngine, SettingsStore) {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AirStatTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = SettingsStore(directory: dir)
+        store.update {
+            $0.general.pausesOnLowPower = pausesOnLowPower
+            $0.general.throttlesWhenOccluded = throttlesWhenOccluded
+        }
+        let engine = MetricsEngine(settingsStore: store)
+        // The pause waits for rate collectors to have something to freeze on, so an
+        // engine that has never ingested anything can never be paused.
+        engine.ingest(.empty)
+        engine.ingest(.empty)
+        return (engine, store)
+    }
+
+    @Test("low power mode suspends sampling when the setting is on")
+    func lowPowerSuspends() {
+        let (engine, _) = makeEngine(pausesOnLowPower: true)
+        engine.setLowPowerMode(false)
+        #expect(engine.activity == .menuBar)
+        engine.setLowPowerMode(true)
+        #expect(engine.activity == .suspended)
+    }
+
+    @Test("the pause waits for the first samples rather than freezing on nothing")
+    func pauseWaitsForWarmUp() {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("AirStatTests-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let store = SettingsStore(directory: dir)
+        store.update { $0.general.pausesOnLowPower = true }
+        let engine = MetricsEngine(settingsStore: store)
+
+        engine.setLowPowerMode(true)
+        #expect(engine.activity == .menuBar, "paused before any sample had been taken")
+        engine.ingest(.empty)
+        #expect(engine.activity == .menuBar, "paused while rates were still baselining")
+        engine.ingest(.empty)
+        #expect(engine.activity == .suspended)
+    }
+
+    @Test("low power mode is ignored when the setting is off")
+    func lowPowerIgnoredWhenSettingOff() {
+        let (engine, _) = makeEngine(pausesOnLowPower: false)
+        engine.setLowPowerMode(true)
+        #expect(engine.activity == .menuBar)
+    }
+
+    @Test("leaving low power mode resumes sampling")
+    func leavingLowPowerResumes() {
+        let (engine, _) = makeEngine(pausesOnLowPower: true)
+        engine.setLowPowerMode(true)
+        #expect(engine.activity == .suspended)
+        engine.setLowPowerMode(false)
+        #expect(engine.activity == .menuBar)
+    }
+
+    @Test("turning the setting off resumes sampling without leaving low power mode")
+    func turningSettingOffResumes() {
+        let (engine, store) = makeEngine(pausesOnLowPower: true)
+        engine.setLowPowerMode(true)
+        #expect(engine.activity == .suspended)
+        store.update { $0.general.pausesOnLowPower = false }
+        engine.applySettings()
+        #expect(engine.activity == .menuBar)
+    }
+
+    @Test("a surface the user opened keeps sampling through the pause")
+    func openSurfacesOutrankThePause() {
+        let (engine, _) = makeEngine(pausesOnLowPower: true)
+        engine.setLowPowerMode(true)
+        engine.setPanelVisible(true)
+        #expect(engine.activity == .panel)
+        engine.setPanelVisible(false)
+        #expect(engine.activity == .suspended)
+        engine.setOverlayVisible(true)
+        #expect(engine.activity == .overlay)
+    }
+
+    @Test("the pause outranks the occlusion throttle")
+    func pauseOutranksThrottle() {
+        let (engine, _) = makeEngine(pausesOnLowPower: true, throttlesWhenOccluded: true)
+        engine.setMenuBarOccluded(true)
+        #expect(engine.activity == .occluded)
+        engine.setLowPowerMode(true)
+        #expect(engine.activity == .suspended)
+    }
+
+    @Test("sleep still wins over everything")
+    func sleepWins() {
+        let (engine, _) = makeEngine(pausesOnLowPower: true)
+        engine.setPanelVisible(true)
+        engine.setLowPowerMode(true)
+        engine.setSystemAsleep(true)
+        #expect(engine.activity == .suspended)
+    }
+
+    @Test("the power state observer is removed, not left behind")
+    func observerIsTornDown() {
+        // The pause stays off so the assertions do not depend on whether the machine
+        // running the suite happens to be in Low Power Mode.
+        let (engine, _) = makeEngine(pausesOnLowPower: false)
+        #expect(engine.isObservingPowerState == false)
+        engine.beginObservingPowerState()
+        #expect(engine.isObservingPowerState)
+        engine.beginObservingPowerState()
+        engine.endObservingPowerState()
+        #expect(engine.isObservingPowerState == false, "a second install left an observer behind")
+    }
+}

--- a/Tests/AirStatKitTests/PublicIPFetcherTests.swift
+++ b/Tests/AirStatKitTests/PublicIPFetcherTests.swift
@@ -1,0 +1,190 @@
+import Testing
+import Foundation
+@testable import AirStatKit
+
+/// Everything here runs against a stub transport. The one part of this feature that
+/// needs the internet is the round trip itself; the parts worth guarding are the ones
+/// that decide whether the round trip happens at all.
+@Suite("Public IP fetcher")
+struct PublicIPFetcherTests {
+
+    /// Counts what would have left the machine and answers on demand, so a test can
+    /// assert on requests without making one.
+    private final class Recorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var pending: [(MetricState<String>) -> Void] = []
+        private var requests = 0
+
+        var transport: PublicIPTransport {
+            { [self] completion in
+                lock.lock()
+                requests += 1
+                pending.append(completion)
+                lock.unlock()
+            }
+        }
+
+        var requestCount: Int {
+            lock.lock()
+            defer { lock.unlock() }
+            return requests
+        }
+
+        /// Completes every outstanding request with the same answer.
+        func answer(_ state: MetricState<String>) {
+            lock.lock()
+            let completions = pending
+            pending.removeAll()
+            lock.unlock()
+            for completion in completions { completion(state) }
+        }
+    }
+
+    @Test("nothing is sent until the user opts in")
+    func gatedOnTheSetting() {
+        let recorder = Recorder()
+        let fetcher = PublicIPFetcher(transport: recorder.transport)
+
+        for _ in 0..<5 { fetcher.refreshIfDue() }
+
+        #expect(recorder.requestCount == 0)
+        #expect(fetcher.currentState().value == nil)
+        // The panel keys the row's presence off this: unsupported means "not asked for",
+        // which is why the row is absent rather than empty while the toggle is down.
+        #expect(fetcher.currentState().isPermanentlyUnavailable)
+    }
+
+    @Test("opting in produces exactly one lookup")
+    func oneLookupOnEnable() {
+        let recorder = Recorder()
+        let fetcher = PublicIPFetcher(transport: recorder.transport)
+
+        fetcher.setEnabled(true)
+        #expect(recorder.requestCount == 0)
+        #expect(fetcher.currentState().failure == .pending)
+
+        fetcher.refreshIfDue()
+        #expect(recorder.requestCount == 1)
+
+        // A second tick while the first request is still out must not open another.
+        fetcher.refreshIfDue()
+        #expect(recorder.requestCount == 1)
+
+        recorder.answer(.value("198.51.100.7"))
+        #expect(fetcher.currentState().value == "198.51.100.7")
+    }
+
+    @Test("a cached address is not looked up again on the next tick")
+    func throttledAfterSuccess() {
+        let recorder = Recorder()
+        let fetcher = PublicIPFetcher(transport: recorder.transport)
+        fetcher.setEnabled(true)
+        fetcher.refreshIfDue()
+        recorder.answer(.value("198.51.100.7"))
+
+        // The sampling queue calls this every second or two for the life of the app.
+        for _ in 0..<200 { fetcher.refreshIfDue() }
+
+        #expect(recorder.requestCount == 1)
+        #expect(fetcher.currentState().value == "198.51.100.7")
+    }
+
+    @Test("a failed lookup is not retried on the next tick either")
+    func throttledAfterFailure() {
+        let recorder = Recorder()
+        let fetcher = PublicIPFetcher(transport: recorder.transport)
+        fetcher.setEnabled(true)
+        fetcher.refreshIfDue()
+        recorder.answer(.failure(.failed("could not reach the lookup service")))
+
+        for _ in 0..<200 { fetcher.refreshIfDue() }
+
+        #expect(recorder.requestCount == 1)
+        #expect(fetcher.currentState().failure == .failed("could not reach the lookup service"))
+    }
+
+    /// The intervals themselves, because the whole justification for talking to a third
+    /// party at all is that it happens rarely. A future edit that drops either of these
+    /// to seconds should fail here rather than ship.
+    @Test("the throttle is measured in many minutes")
+    func intervalsAreLong() {
+        #expect(PublicIPFetcher.refreshInterval == 30 * 60)
+        #expect(PublicIPFetcher.retryInterval == 2 * 60)
+        #expect(PublicIPFetcher.retryInterval < PublicIPFetcher.refreshInterval)
+    }
+
+    @Test("turning the toggle off clears the cached address and stops lookups")
+    func disablingClearsTheCache() {
+        let recorder = Recorder()
+        let fetcher = PublicIPFetcher(transport: recorder.transport)
+        fetcher.setEnabled(true)
+        fetcher.refreshIfDue()
+        recorder.answer(.value("198.51.100.7"))
+        #expect(fetcher.currentState().value == "198.51.100.7")
+
+        fetcher.setEnabled(false)
+
+        #expect(fetcher.currentState().value == nil)
+        #expect(fetcher.currentState().isPermanentlyUnavailable)
+        for _ in 0..<5 { fetcher.refreshIfDue() }
+        #expect(recorder.requestCount == 1)
+    }
+
+    @Test("a reply that arrives after the toggle goes off is discarded")
+    func lateReplyIsDropped() {
+        let recorder = Recorder()
+        let fetcher = PublicIPFetcher(transport: recorder.transport)
+        fetcher.setEnabled(true)
+        fetcher.refreshIfDue()
+
+        fetcher.setEnabled(false)
+        recorder.answer(.value("198.51.100.7"))
+
+        #expect(fetcher.currentState().value == nil)
+        #expect(fetcher.currentState().isPermanentlyUnavailable)
+    }
+
+    @Test("switching back on starts from pending, not from the old address")
+    func reenablingDoesNotShowStaleAddress() {
+        let recorder = Recorder()
+        let fetcher = PublicIPFetcher(transport: recorder.transport)
+        fetcher.setEnabled(true)
+        fetcher.refreshIfDue()
+        recorder.answer(.value("198.51.100.7"))
+
+        fetcher.setEnabled(false)
+        fetcher.setEnabled(true)
+
+        #expect(fetcher.currentState().failure == .pending)
+        fetcher.refreshIfDue()
+        #expect(recorder.requestCount == 2)
+    }
+
+    @Test("only a reply that parses as an address is displayed")
+    func repliesAreValidated() {
+        let ok = PublicIPFetcher.interpret(data: Data("198.51.100.7\n".utf8),
+                                           response: nil, error: nil)
+        #expect(ok.value == "198.51.100.7")
+
+        let v6 = PublicIPFetcher.interpret(data: Data("2001:db8::1".utf8),
+                                           response: nil, error: nil)
+        #expect(v6.value == "2001:db8::1")
+
+        // What a captive portal hands back: a 200, and its login page in the body.
+        let portal = PublicIPFetcher.interpret(data: Data("<html>Sign in</html>".utf8),
+                                               response: nil, error: nil)
+        #expect(portal.value == nil)
+
+        let response = HTTPURLResponse(url: PublicIPFetcher.endpoint, statusCode: 503,
+                                       httpVersion: nil, headerFields: nil)
+        let serverError = PublicIPFetcher.interpret(data: Data("198.51.100.7".utf8),
+                                                    response: response, error: nil)
+        #expect(serverError.value == nil)
+
+        let offline = PublicIPFetcher.interpret(
+            data: nil, response: nil,
+            error: URLError(.notConnectedToInternet))
+        #expect(offline.value == nil)
+        #expect(offline.failure?.isPermanent == false)
+    }
+}

--- a/Tests/AirStatKitTests/ThresholdEvaluatorTests.swift
+++ b/Tests/AirStatKitTests/ThresholdEvaluatorTests.swift
@@ -1,0 +1,246 @@
+import Testing
+import Foundation
+@testable import AirStatKit
+@testable import AirStatUI
+
+@Suite("Threshold rules only fire when they have earned it")
+struct ThresholdEvaluatorTests {
+
+    private let start = Date(timeIntervalSince1970: 1_000_000)
+
+    private func rule(_ metric: ThresholdMetric, threshold: Double,
+                      sustainedFor: TimeInterval = 30, cooldown: TimeInterval = 900) -> ThresholdRule {
+        ThresholdRule(metric: metric, threshold: threshold, isEnabled: true,
+                      sustainedFor: sustainedFor, cooldown: cooldown)
+    }
+
+    /// Feeds one reading per two-second sample for `seconds` and collects everything
+    /// that fired, which is the cadence the engine actually publishes at.
+    private func run(_ evaluator: inout ThresholdEvaluator, rule: ThresholdRule,
+                     value: Double?, from offset: TimeInterval, seconds: TimeInterval) -> [ThresholdAlert] {
+        var alerts: [ThresholdAlert] = []
+        var t = offset
+        while t < offset + seconds {
+            let readings = value.map { [rule.metric: $0] } ?? [:]
+            alerts += evaluator.alerts(for: [rule], readings: readings,
+                                       now: start.addingTimeInterval(t))
+            t += 2
+        }
+        return alerts
+    }
+
+    @Test("a spike shorter than the sustained duration never alerts")
+    func transientSpikeIsIgnored() {
+        var evaluator = ThresholdEvaluator()
+        let cpu = rule(.cpuUsage, threshold: 90, sustainedFor: 30)
+
+        let spiking = run(&evaluator, rule: cpu, value: 99, from: 0, seconds: 10)
+        let recovered = run(&evaluator, rule: cpu, value: 4, from: 10, seconds: 10)
+        // Back over the line, but the clock restarted, so 10 s of breach is still
+        // 10 s short of the 30 s the user asked for.
+        let spikingAgain = run(&evaluator, rule: cpu, value: 99, from: 20, seconds: 10)
+
+        #expect(spiking.isEmpty)
+        #expect(recovered.isEmpty)
+        #expect(spikingAgain.isEmpty)
+    }
+
+    @Test("a breach held past the sustained duration alerts once")
+    func sustainedBreachAlertsOnce() {
+        var evaluator = ThresholdEvaluator()
+        let cpu = rule(.cpuUsage, threshold: 90, sustainedFor: 30)
+
+        let alerts = run(&evaluator, rule: cpu, value: 96, from: 0, seconds: 60)
+
+        #expect(alerts.count == 1)
+        #expect(alerts.first?.metric == .cpuUsage)
+        #expect(alerts.first?.value == 96)
+        #expect(alerts.first?.threshold == 90)
+    }
+
+    @Test("a zero sustained duration alerts on the first breaching sample")
+    func zeroSustainedFiresImmediately() {
+        var evaluator = ThresholdEvaluator()
+        let cpu = rule(.cpuUsage, threshold: 90, sustainedFor: 0)
+
+        let alerts = evaluator.alerts(for: [cpu], readings: [.cpuUsage: 91], now: start)
+
+        #expect(alerts.count == 1)
+    }
+
+    @Test("cooldown holds the second alert back until it has elapsed")
+    func cooldownSuppressesRepeats() {
+        var evaluator = ThresholdEvaluator()
+        let cpu = rule(.cpuUsage, threshold: 90, sustainedFor: 0, cooldown: 300)
+
+        let first = evaluator.alerts(for: [cpu], readings: [.cpuUsage: 95], now: start)
+        let duringCooldown = run(&evaluator, rule: cpu, value: 95, from: 2, seconds: 296)
+        let afterCooldown = evaluator.alerts(for: [cpu], readings: [.cpuUsage: 95],
+                                             now: start.addingTimeInterval(300))
+
+        #expect(first.count == 1)
+        #expect(duringCooldown.isEmpty)
+        #expect(afterCooldown.count == 1)
+    }
+
+    @Test("a metric with no reading stops the clock rather than crediting the time")
+    func missingReadingRestartsTheClock() {
+        var evaluator = ThresholdEvaluator()
+        let temperature = rule(.cpuTemperature, threshold: 95, sustainedFor: 30)
+
+        let breaching = run(&evaluator, rule: temperature, value: 99, from: 0, seconds: 20)
+        let unreadable = run(&evaluator, rule: temperature, value: nil, from: 20, seconds: 20)
+        let breachingAgain = run(&evaluator, rule: temperature, value: 99, from: 40, seconds: 20)
+
+        #expect(breaching.isEmpty)
+        #expect(unreadable.isEmpty)
+        #expect(breachingAgain.isEmpty)
+    }
+
+    @Test("falling metrics fire below the threshold, rising metrics above it")
+    func directionIsPerMetric() {
+        #expect(ThresholdMetric.batteryLow.isBreached(by: 15, threshold: 20))
+        #expect(!ThresholdMetric.batteryLow.isBreached(by: 40, threshold: 20))
+        #expect(ThresholdMetric.diskFree.isBreached(by: 4, threshold: 10))
+        #expect(!ThresholdMetric.diskFree.isBreached(by: 60, threshold: 10))
+
+        #expect(ThresholdMetric.cpuUsage.isBreached(by: 95, threshold: 90))
+        #expect(!ThresholdMetric.cpuUsage.isBreached(by: 12, threshold: 90))
+        #expect(ThresholdMetric.memoryPressure.isBreached(by: 85, threshold: 80))
+        #expect(!ThresholdMetric.memoryPressure.isBreached(by: 30, threshold: 80))
+        #expect(ThresholdMetric.cpuTemperature.isBreached(by: 101, threshold: 95))
+        #expect(!ThresholdMetric.cpuTemperature.isBreached(by: 45, threshold: 95))
+        #expect(ThresholdMetric.thermalPressure.isBreached(by: 3, threshold: 2))
+        #expect(!ThresholdMetric.thermalPressure.isBreached(by: 0, threshold: 2))
+        #expect(ThresholdMetric.batteryFull.isBreached(by: 100, threshold: 100))
+        #expect(!ThresholdMetric.batteryFull.isBreached(by: 82, threshold: 100))
+    }
+
+    @Test("a full battery alerts once and not again until it leaves the threshold")
+    func batteryFullDoesNotRepeat() {
+        var evaluator = ThresholdEvaluator()
+        let full = rule(.batteryFull, threshold: 100, sustainedFor: 0, cooldown: 60)
+
+        let reachesFull = evaluator.alerts(for: [full], readings: [.batteryFull: 100], now: start)
+        // Six hours on the charger at 100%, which is twenty-four cooldowns.
+        let leftOnCharger = run(&evaluator, rule: full, value: 100, from: 2, seconds: 21_600)
+        let drainsAndReturns = evaluator.alerts(for: [full], readings: [.batteryFull: 96],
+                                                now: start.addingTimeInterval(21_700))
+            + evaluator.alerts(for: [full], readings: [.batteryFull: 100],
+                               now: start.addingTimeInterval(21_800))
+
+        #expect(reachesFull.count == 1)
+        #expect(leftOnCharger.isEmpty)
+        #expect(drainsAndReturns.count == 1)
+    }
+
+    @Test("state for a rule the user switched off is dropped, not carried")
+    func disabledRuleStateIsDropped() {
+        var evaluator = ThresholdEvaluator()
+        let cpu = rule(.cpuUsage, threshold: 90, sustainedFor: 30)
+
+        _ = run(&evaluator, rule: cpu, value: 99, from: 0, seconds: 20)
+        #expect(evaluator.trackedRuleCount == 1)
+
+        // The monitor passes only the rules cleared for delivery, so a rule switched
+        // off arrives as an absence.
+        _ = evaluator.alerts(for: [], readings: [.cpuUsage: 99], now: start.addingTimeInterval(22))
+        #expect(evaluator.trackedRuleCount == 0)
+
+        // Switched back on, the 20 s already served does not count towards the 30 s.
+        let resumed = run(&evaluator, rule: cpu, value: 99, from: 24, seconds: 20)
+        #expect(resumed.isEmpty)
+    }
+
+    @Test("reset clears every rule's bookkeeping")
+    func resetClearsState() {
+        var evaluator = ThresholdEvaluator()
+        _ = evaluator.alerts(for: [rule(.cpuUsage, threshold: 90)],
+                             readings: [.cpuUsage: 99], now: start)
+        #expect(evaluator.trackedRuleCount == 1)
+
+        evaluator.reset()
+        #expect(evaluator.trackedRuleCount == 0)
+    }
+
+    @Test("two breaching rules both fire in one pass")
+    func independentRulesDoNotInterfere() {
+        var evaluator = ThresholdEvaluator()
+        let cpu = rule(.cpuUsage, threshold: 90, sustainedFor: 0)
+        let memory = rule(.memoryPressure, threshold: 80, sustainedFor: 0)
+
+        let alerts = evaluator.alerts(for: [cpu, memory],
+                                      readings: [.cpuUsage: 92, .memoryPressure: 88],
+                                      now: start)
+
+        #expect(Set(alerts.map(\.metric)) == [.cpuUsage, .memoryPressure])
+    }
+}
+
+@Suite("Snapshot readings arrive in the units the rules are written in")
+struct ThresholdReadingTests {
+
+    private func volume(availableBytes: UInt64) -> VolumeInfo {
+        VolumeInfo(id: "root", name: "Macintosh HD", path: "/", totalBytes: 494_384_795_648,
+                   freeBytes: availableBytes, availableBytes: availableBytes, isRoot: true)
+    }
+
+    @Test("percentages come through as percentages, not fractions")
+    func fractionsBecomePercentages() {
+        let snapshot = SystemSnapshot(
+            cpu: .value(CPUSnapshot(total: CPULoad(user: 0.5, system: 0.24, idle: 0.26))),
+            memory: .value(MemorySnapshot(pressureFraction: 0.62)))
+        let readings = ThresholdEvaluator.readings(from: snapshot)
+
+        #expect(readings[.cpuUsage].map { Int($0.rounded()) } == 74)
+        #expect(readings[.memoryPressure].map { Int($0.rounded()) } == 62)
+    }
+
+    @Test("free disk space is reported in the GB the rule asks for")
+    func diskFreeIsGigabytes() {
+        let snapshot = SystemSnapshot(disk: .value(DiskSnapshot(volumes: [volume(availableBytes: 8_500_000_000)])))
+        let readings = ThresholdEvaluator.readings(from: snapshot)
+
+        #expect(readings[.diskFree].map { Int($0.rounded()) } == 9)
+    }
+
+    @Test("battery rules split on whether the machine is on the charger")
+    func batteryReadingsSplitByChargeState() {
+        let discharging = ThresholdEvaluator.readings(
+            from: SystemSnapshot(power: .value(PowerSnapshot(hasBattery: true, percentage: 14,
+                                                            isPluggedIn: false))))
+        #expect(discharging[.batteryLow] == 14)
+        #expect(discharging[.batteryFull] == nil)
+
+        let charging = ThresholdEvaluator.readings(
+            from: SystemSnapshot(power: .value(PowerSnapshot(hasBattery: true, percentage: 100,
+                                                            isCharging: false, isPluggedIn: true,
+                                                            isFullyCharged: true))))
+        #expect(charging[.batteryFull] == 100)
+        #expect(charging[.batteryLow] == nil)
+    }
+
+    @Test("a Mac with no battery produces no battery readings")
+    func missingBatteryProducesNoReading() {
+        let readings = ThresholdEvaluator.readings(
+            from: SystemSnapshot(power: .value(PowerSnapshot(hasBattery: false, percentage: nil))))
+
+        #expect(readings[.batteryLow] == nil)
+        #expect(readings[.batteryFull] == nil)
+    }
+
+    @Test("thermal pressure reads as its level, and an unreadable sensor reads as nothing")
+    func thermalReadings() {
+        let readings = ThresholdEvaluator.readings(
+            from: SystemSnapshot(thermal: .value(ThermalSnapshot(pressure: .serious, cpuCelsius: nil,
+                                                                 sensorsUnavailableReason: "No readable sensors."))))
+
+        #expect(readings[.thermalPressure] == 2)
+        #expect(readings[.cpuTemperature] == nil)
+    }
+
+    @Test("a pending snapshot yields no readings at all")
+    func pendingSnapshotIsSilent() {
+        #expect(ThresholdEvaluator.readings(from: .empty).isEmpty)
+    }
+}

--- a/docs/BUG-REPORT.md
+++ b/docs/BUG-REPORT.md
@@ -1,0 +1,404 @@
+# AirStats manual test report
+
+**Date:** 2026-08-05
+**Build:** `Scripts/build.sh release` at working tree `bbc9088` + uncommitted rename to `AirStats`
+**Machine:** MacBook Pro (14-inch, Nov 2023), Apple M3 Pro, 18 GB, macOS 26.5.2 (25F84)
+**Method:** the installed `/Applications/AirStats.app` driven through the macOS
+Accessibility API (`AXUIElementPerformAction`, synthetic `CGEvent` clicks and keys),
+with every state change checked against
+`~/Library/Application Support/AirStat/settings.json` and against the live status item.
+Screen Recording is not granted in this environment, so nothing here rests on a
+screenshot; layout claims are stated as accessibility frame geometry, which is what
+AppKit actually laid out.
+
+Nine issues. One is a hard crash. Five are controls that persist a preference and
+change nothing. The rest are a layout break, an accessibility gap, and leftovers from
+the `AirStat` to `AirStats` rename.
+
+A tenth was raised and then withdrawn. B10 is kept in place, marked WITHDRAWN, because
+the false reasoning behind it will catch the next person who tests this app.
+
+---
+
+## B1. Crash: `MenuBarPane` reads a stale index after the readout list shrinks
+
+**Severity:** critical, the whole app dies
+**File:** `Sources/AirStatUI/Settings/MenuBarPane.swift:224`, `:240`, `:250`
+**Crash reports:** `~/Library/Logs/DiagnosticReports/AirStats-2026-08-05-224135.ips`,
+`AirStats-2026-08-05-224256.ips`
+
+### Reproduction
+
+1. Settings, Menu Bar.
+2. Add readouts until there are more than two (the pane's `Add Module` menu).
+3. Click any readout row past index 1 so the `Editing …` section binds to it.
+4. Restore Defaults, then confirm in the sheet.
+
+The readout list resets to the two shipped items while the `Editing` section's
+`Picker` still holds bindings created for the old index. `EXC_BREAKPOINT`, the status
+item vanishes, the app is gone.
+
+### Stack
+
+```
+Swift runtime failure: Index out of range
+Array._checkSubscript(_:wasNativeTypeChecked:)
+Array.subscript.getter
+closure #1 in MenuBarPane.metricBinding(index:)
+SwiftUICore  LocationBox.get()
+SwiftUI      PickerStyleConfiguration.init(selection:)
+SwiftUI      Picker.body.getter
+```
+
+### Cause
+
+All three bindings guard the write and leave the read bare:
+
+```swift
+private func metricBinding(index: Int) -> Binding<MenuBarMetric> {
+    Binding(get: { items[index].metric },              // <- unguarded
+            set: { metric in
+                settings.update { s in
+                    guard s.menuBar.items.indices.contains(index) else { return }   // <- guarded
+                    ...
+```
+
+`styleBinding(index:)` and `captionBinding(index:)` have the same shape, and
+`itemDetail(index:)` opens with a bare `let item = items[index]` at `:173`.
+
+### Other routes to the same crash
+
+- About, Import…, with a settings file whose `menuBar.items` is shorter than the
+  current selection index. Same mechanism, same trap.
+- Any future path that replaces `menuBar.items` wholesale.
+
+`Remove the selected readout` is **not** affected: `removeSelected()` sets
+`selection = nil` at `:307`, so the detail section is gone before the list shrinks.
+Verified by hand, no crash.
+
+`NotificationsPane` is not affected. It binds by `rule.id` through
+`mutate(_:_:)` at `:154` and never subscripts by a captured index. That is the
+pattern `MenuBarPane` should match, or the getters need the same
+`indices.contains` guard the setters already have, falling back to a safe value.
+
+### Fix sketch
+
+Guard every getter, or key the bindings off `MenuBarItemConfig.ID` the way
+`enabledBinding(for:)` at `:212` already does.
+
+---
+
+## B2. "Pause sampling on Low Power Mode" does nothing
+
+**Severity:** high, an advertised power feature is absent
+**File:** `Sources/AirStatUI/Settings/GeneralPane.swift:23`
+
+`general.pausesOnLowPower` is declared in `Settings.swift:690`, coded and decoded,
+written by the toggle, and read by nothing. `grep -rn pausesOnLowPower Sources/`
+returns the toggle and the model only.
+
+Verified live: Low Power Mode was on for the whole session
+(`pmset -g` reports `lowpowermode 1`), the toggle was on, and the status item kept
+updating on its 2 s cadence for five consecutive samples.
+
+Compare `general.throttlesWhenOccluded`, which is wired at
+`MetricsEngine.swift:117` and does work.
+
+---
+
+## B3. "Look up my public IP address" does nothing, and there is nowhere to show it
+
+**Severity:** high, a privacy-framed toggle that implies a network call it never makes
+**File:** `Sources/AirStatUI/Settings/GeneralPane.swift:59`
+
+`general.fetchesPublicIP` is never read. `NetworkCollector.swift:286` hardcodes
+`publicIP: .pending` with the comment:
+
+> A separate opt-in, heavily throttled fetcher owns this field.
+
+That fetcher does not exist. Neither does any UI: `grep -rn publicIP Sources/AirStatUI/`
+returns nothing, so `NetworkSnapshot.publicIP` is never displayed even if it were
+populated. The network module's expanded detail shows Upload, Local IP and Signal
+only.
+
+Either implement the fetcher and a row to show it, or remove the toggle. A privacy
+switch that claims to control an outbound request is worse than no switch when the
+request is not there to control.
+
+---
+
+## B4. "Combine into one menu bar item" does nothing
+
+**Severity:** high, and the UI carries a footnote describing behaviour that does not exist
+**File:** `Sources/AirStatUI/Settings/MenuBarPane.swift:45`
+
+`menuBar.usesCombinedItem` is never read outside the toggle.
+`StatusItemController` holds a single `private var statusItem: NSStatusItem?`
+(`:19`) and `install()` opens with `guard statusItem == nil else { return }` (`:33`).
+One item is all the app can produce.
+
+Verified live: with 16 readouts enabled, turning the switch off left a single 855 pt
+status item unchanged for at least 11 s.
+
+The footnote under it reads:
+
+> One item keeps the readouts together and in order. Separate items can be rearranged
+> among your other menu bar icons, and macOS hides them one at a time when the bar
+> runs out of room.
+
+None of that second sentence is true today.
+
+---
+
+## B5. Keyboard shortcuts are recorded, stored, and never registered
+
+**Severity:** high, three visible controls with no effect
+**File:** `Sources/AirStatUI/Settings/ShortcutRecorder.swift:177`
+
+The General pane offers Show / Hide Panel, Show / Hide Overlay and Open Settings.
+`ShortcutRecorder` records a key combination and writes it to
+`shortcuts.bindings[action]`. Nothing reads it back.
+
+There is no `RegisterEventHotKey`, no `CGEvent` tap, and no global key-down monitor
+that dispatches a shortcut action anywhere in the source. The only global monitors
+are `PanelController.swift:288` (Escape to dismiss the panel), `:297` (click outside),
+and `OverlayController.swift:296`/`:326` (pointer proximity and modifier watching for
+the overlay grab gesture).
+
+---
+
+## B6. Notification rules drive a monitor that is an empty stub
+
+**Severity:** high, an entire settings pane is inert
+**File:** `Sources/AirStatUI/Support/ThresholdMonitor.swift:19`
+
+```swift
+/// Watches metrics against the user's threshold rules and posts notifications.
+///
+/// Sustained-duration and cooldown handling live here so a transient spike while
+/// launching an app never produces an alert.
+public func start() {}
+public func stop() {}
+```
+
+`AppCoordinator.start()` calls `thresholdMonitor.start()` at `:55`, so the wiring is
+in place and the body is missing. There is no `UNUserNotificationCenter` reference in
+the project, no authorisation request, and no delivery.
+
+The Notifications pane is fully built on top of this: a master switch, seven rules
+with metric-specific ranges and units, per-rule sustained-duration pickers and
+cooldowns, plus availability badges for metrics this Mac cannot measure. All of it
+persists correctly and none of it can ever fire.
+
+---
+
+## B7. The Menu Bar pane's preview blows the settings window layout apart
+
+**Severity:** medium, visible corruption at a reachable configuration
+**File:** `Sources/AirStatUI/Settings/SettingsSupport.swift:493` (`MenuBarPreviewStrip`)
+
+`MenuBarPreviewStrip` lays its content out in an `HStack` with
+`.frame(maxWidth: .infinity)` and no upper bound, no `.lineLimit`, and no horizontal
+scroll container. Its intrinsic width grows with the number of enabled readouts, and
+because the settings root is an `HStack` of sidebar plus pane, the excess pushes both
+children outside the window frame.
+
+Measured, settings window fixed at `760x616` starting at x=376 (so it spans 376 to 1136):
+
+| Readouts | Sidebar frame | Preview frame |
+|---|---|---|
+| 2 (default) | `@376,173 184x560` | `@591,229 515x38` |
+| 16 | `@292,173 184x560` | `@372,229 954x181` |
+
+At 16 readouts the sidebar starts 84 pt to the left of the window's left edge and the
+preview runs 190 pt past its right edge. The layout snaps back exactly when the
+readout list returns to two, which isolates the preview as the cause.
+
+The preview needs a hard width ceiling with the overflow clipped or scrolled, the way
+the real menu bar truncates.
+
+---
+
+## B8. The settings sidebar exposes no press action to assistive technology
+
+**Severity:** medium, VoiceOver cannot change panes
+**File:** `Sources/AirStatUI/Settings/SettingsWindowController.swift:233`
+
+Each sidebar row is a real `Button`, but the accessibility modifiers applied outside
+it replace the element and drop its action:
+
+```swift
+.accessibilityElement(children: .ignore)
+.accessibilityLabel(item.label)
+.accessibilityAddTraits(item == tab ? [.isSelected, .isButton] : .isButton)
+```
+
+`AXUIElementCopyActionNames` on all six rows returns an empty list. They report role
+`AXButton` and the `.isButton` trait, so assistive technology presents them as
+buttons, and `AXPress` on them does nothing. Verified: `AXPress` on the Menu Bar row
+returned success and the pane did not change; a synthetic mouse click at the same
+point switched panes immediately.
+
+Every other control in the app is fine here. The panel's module headers, the readout
+checkboxes, the reorder arrows, the popups and the Restore Defaults buttons all carry
+`actions=[Press]`. Those use `.accessibilityLabel` / `.accessibilityValue` /
+`.accessibilityHint` without `.accessibilityElement(children: .ignore)`, which is the
+difference.
+
+The comment above the modifiers explains the intent (announce "General, selected,
+button" rather than walking into the row's decoration). Keeping that announcement
+while restoring the action means either dropping `children: .ignore` or adding an
+explicit `.accessibilityAction`.
+
+---
+
+## B9. Rename leftovers: the app calls itself "AirStat" in four user-visible places
+
+**Severity:** low, but it is on the launch surface
+
+| Location | Text |
+|---|---|
+| `Sources/AirStatUI/Settings/GeneralPane.swift:52` | `Toggle("Open AirStat at login", …)` |
+| `Sources/AirStatUI/Settings/AppearancePane.swift:145` | `.accessibilityHint("Returns \(label) to the colour AirStat ships with")` |
+| `Sources/AirStats/DiagnosticsCLI.swift` | `--probe` header prints `AirStat metric probe` |
+| `Resources/Info.plist:10` | `CFBundleIdentifier` is `com.airstat.AirStat` |
+
+The bundle identifier is deliberate if it is being kept for continuity of
+`UserDefaults` and the settings directory (`~/Library/Application Support/AirStat`).
+Worth a comment in `Info.plist` saying so, otherwise someone will "fix" it and orphan
+every existing user's settings.
+
+Separately, `Scripts/build.sh:34` globs `"$BIN_DIR"/*_AirStatUI.bundle` and copies
+every match. A tree that has been built under both names ships both
+`AirStat_AirStatUI.bundle` and `AirStats_AirStatUI.bundle` inside
+`Contents/Resources`. Confirmed in the installed bundle this session. Harmless at
+runtime because `Bundle.module` looks for the current name, but it is dead weight in
+the shipped app and a `rm -rf .build` masks it.
+
+---
+
+## B10. WITHDRAWN as unproven. Needs one retest after unlock
+
+Kept rather than deleted, because the reasoning is a trap worth marking for whoever
+tests this app next.
+
+Late in the session the panel appeared to publish nothing to accessibility. The
+app's own log showed it on screen, and every reader reported an empty tree:
+
+```
+[airstat.window] panel shown frame=(780.0, 198.0, 340.0, 743.0) key=false appActive=false
+ax <pid> windows                                       -> (no windows)
+System Events: count of windows of process "AirStats"  -> 0
+```
+
+I concluded the panel was invisible to VoiceOver and wrote it up as a high-severity
+defect, reasoning that `PanelController.show()` deliberately avoids `makeKey()` and
+that an inactive app must therefore fail to publish.
+
+That was wrong. **macOS disables the accessibility API while the screen is locked**,
+and this machine locked at 23:20. The control that settles it:
+
+```
+CGSSessionScreenIsLocked = 1
+CGSSessionScreenLockedTime = 1785996012   (23:20:12)
+
+System Events, count of windows:  Finder 0,  Safari 0,  TextEdit 0,  ghostty 0
+```
+
+Those apps all had windows on screen. Every app reports zero, so nothing about
+AirStats is implicated.
+
+The timing explains the whole confusion. Every AX tree quoted in this report was
+captured between 22:24 and about 23:05, before the lock, which is why they are rich
+and complete: 43 elements in the panel, correct `AXDescription` and `AXValue` on
+every row, `AXPress` working throughout. Everything measured after 23:20 was empty.
+Two of us independently invented app-shaped explanations for an environmental cause,
+one reaching for "never activated" and one for "never made key", and both fit the
+data.
+
+**The lesson for the next person driving this app: check
+`CGSSessionScreenIsLocked` before concluding anything from an empty accessibility
+tree, and confirm against a control app you know has windows.** This is now recorded
+in `CLAUDE.md` beside the `screencapture` note.
+
+### Withdrawn as unproven, not as disproven
+
+Being precise about what survives, because it would be just as sloppy to claim the
+lock disproves B10 as it was to claim the empty tree proved it.
+
+Of the three measurements above, two go through the accessibility API and are
+worthless while it is switched off. The third, the app's own `appActive=false` log
+line, is lock-independent but only establishes that the app was inactive; it says
+nothing about whether an inactive app publishes windows. So **there is no surviving
+evidence for B10, and none against it either.** It cannot be tested until the machine
+is unlocked.
+
+The one thing pointing away from it: before the lock, the panel *was* enumerable.
+`ax AirStats press X/0` followed by `ax AirStats dump` returned the full 43-element
+panel tree at a point in the session when only the status item had been pressed and
+the Settings window had never been opened. If the app was inactive at that moment,
+that is a direct counterexample. I did not record `NSApp.isActive` at the time, so I
+cannot close it from the transcript.
+
+**The retest, once unlocked:** launch the installed app clean, do not click it, press
+the status item through `AXPress` only, and compare `System Events: count of windows`
+against a control app in the same breath. If AirStats reports 0 while the control
+reports non-zero, B10 is real and belongs to `PanelController.swift`. If both report
+their windows, it is closed for good. Two minutes of work.
+
+B8 is unaffected either way: it was measured before the lock. Its fix is written and
+builds clean, but its before/after accessibility capture is still outstanding for the
+same reason, so B8 is **fixed but not yet re-verified**.
+
+---
+
+## What was exercised and found correct
+
+Recorded so the report is not read as a list of everything that was touched.
+
+**Panel.** All nine modules expand and collapse, state persists across close and
+reopen, and every detail row carries a correct accessibility label and value. The
+panel sizes to its content, re-anchors when the status item changes width, and
+centres correctly under an 855 pt status item. Footer Settings and Quit work.
+
+**Menu bar.** All 16 metrics can be added. All four display styles (Text, Graph,
+Text & Graph, Icon & Text) render and change the item's width. Reordering, enabling,
+disabling and removing all behave. Metrics this Mac cannot measure are marked
+"(unavailable here)" in the add menu and render as unavailable rather than as zero.
+The accessibility value is a full readable sentence.
+
+**Sampling.** The update interval is honoured end to end: at 30 s the status item held
+a constant value across 18 s of polling, at 2 s it tracked. `throttlesWhenOccluded`
+is wired.
+
+**Settings.** Every popup, switch and slider outside the issues above writes through
+to `settings.json` correctly. Restore Defaults is section-scoped and confirms first.
+Colour wells work, the "All Metrics" master swatch writes every metric at once, and
+"Use Default" clears an override. The shared `NSColorPanel` closes both when the pane
+changes and when the window closes, which is the documented hazard in `CLAUDE.md` and
+it is handled.
+
+**Overlay.** Enabling shows the window, it restores on relaunch (verified through
+`AIRSTAT_WINDOW_LOG=1`: `overlay shown frame=(16.0, 800.0, 220.0, 133.0) level=1000`),
+and the corner setting is applied. Modules add, remove and reorder.
+
+**CLI.** `--help`, `--probe` (all nine collectors, sane values) and `--render` (64
+images across four surfaces, four scenarios, two appearances, two scales) all
+succeed.
+
+**Tests.** `swift test`: 33 tests pass in 3.0 s.
+
+---
+
+## Not covered
+
+- The status item's right-click context menu. `AppCoordinator.showContextMenu()`
+  builds it and `StatusItemController` configures
+  `sendAction(on: [.leftMouseUp, .rightMouseUp])` correctly, but synthetic `CGEvent`
+  mouse clicks do not reach the menu bar in this environment, and `AXPress` on a menu
+  extra only delivers the primary action. Needs a human click.
+- Anything that depends on seeing pixels: material and translucency, hover states,
+  animation, the overlay's drag-to-move gesture and click-through behaviour.
+- Multi-display and Space-change behaviour.
+- Login item registration. Toggling it writes the preference and calls
+  `LoginItem.synchronize`, but confirming registration with `launchd` was out of scope.


### PR DESCRIPTION
Drove the installed app by hand through the Accessibility API and checked every state change against `settings.json` and the live status item. Nine issues, written up in full at `docs/BUG-REPORT.md`.

## What was wrong

One hard crash, five controls that persisted a preference and changed nothing, a layout break, an accessibility gap, and rename leftovers.

| | Issue | Verified |
|---|---|---|
| B1 | `MenuBarPane` trapped on a stale index when the readout list shrank under the editor. Restore Defaults with any readout past index 1 selected killed the app | yes, isolated-copy repro dies before and survives after |
| B2 | `pausesOnLowPower` was read by nothing | yes, status item frozen with it on and live with it off, same machine |
| B3 | `fetchesPublicIP` was read by nothing, and no UI ever showed the field | partly, real address through the full chain |
| B4 | `usesCombinedItem` was read by nothing; the app could only ever make one status item | yes, 1 item combined, 5 separate |
| B5 | Recorded shortcuts were stored and never registered | no, needs a human key press |
| B6 | `ThresholdMonitor.start()` was an empty stub under a fully built settings pane | no, needs notification permission |
| B7 | The menu bar preview grew past the settings window at 16 readouts, pushing the sidebar 84pt off the left edge | yes, measured before and after |
| B8 | Settings sidebar rows exposed no AXPress action, so assistive tech could not change panes | fix written, capture blocked |
| B9 | Four user-visible strings still said "AirStat", including the User-Agent on the one outbound request | yes |

## Not yet verified

B5, B6 and B8 are written and build clean but need physical access:

- **B5**: synthetic key events provably cannot trigger Carbon hot keys. Someone has to press the shortcut.
- **B6**: verified up to the OS boundary. `requestAuthorization` returns "not allowed" because earlier prompts were dismissed while the screen was locked. Needs a human to grant permission.
- **B8**: the screen has been locked since 23:20 and a locked screen empties `AXWindows` for every app, so the before and after capture cannot be taken yet.

A tenth issue was raised and withdrawn as unproven. It is kept in the report marked WITHDRAWN because the reasoning behind it is a trap: an empty accessibility tree looked exactly like a bug in the panel, and two of us independently invented app-shaped explanations before anyone checked a control app. `CLAUDE.md` now records that, and that menu bar extras keep answering while window enumeration goes dark, so a successful read is not evidence the screen is unlocked.

## Notes

- 90 tests pass, up from 33.
- `Package.swift` links AirStatUI into the test target so the pure UI logic (threshold evaluation, binding lifetime) can be tested.
- The bundle identifier and the `~/Library/Application Support/AirStat` directory deliberately keep the old name. Both are now commented to say so, because renaming either would strand every existing user's settings.