### PR TITLE
panel flickering fix

### DIFF
--- a/Sources/AirStatUI/Design/DesignSystem.swift
+++ b/Sources/AirStatUI/Design/DesignSystem.swift
@@ -150,6 +150,9 @@ public enum Design {
     public enum Motion {
         /// Numeric readouts crossfading to a new value.
         public static let value = Animation.easeOut(duration: 0.18)
+        /// A module revealing or hiding its detail while the panel follows its height.
+        public static let disclosureDuration: TimeInterval = 0.18
+        public static let disclosure = Animation.easeOut(duration: disclosureDuration)
         ///
         /// Panel present/dismiss.
         public static let present = Animation.easeOut(duration: 0.14)

--- a/Sources/AirStatUI/Panel/PanelController.swift
+++ b/Sources/AirStatUI/Panel/PanelController.swift
@@ -217,12 +217,19 @@ public final class PanelController: NSObject, NSWindowDelegate {
         }
 
         isDisclosureTransitionActive = true
-        layout.isDisclosureTransitionActive = true
+
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        // Enter the transition on its own layout pass, before the hierarchy changes
+        // shape. The scroll indicator is retired here, so the measurement below cannot
+        // be the pass that flashes one.
+        withTransaction(transaction) {
+            layout.isDisclosureTransitionActive = true
+        }
+        window.layoutIfNeeded()
 
         // Measure the final hierarchy without allowing the staging state to animate or
         // reach the screen. The window itself remains on its current frame throughout.
-        var transaction = Transaction(animation: nil)
-        transaction.disablesAnimations = true
         withTransaction(transaction) {
             layout.collapsedModulesOverride = target
         }
@@ -230,6 +237,30 @@ public final class PanelController: NSObject, NSWindowDelegate {
         let fitting = window.contentView?.fittingSize
             ?? NSSize(width: PanelSettings.width, height: window.frame.height)
         let destination = targetFrame(for: fitting, anchoredTo: lastAnchor, on: lastScreen)
+
+        let duration = disclosureDuration
+        // Reduce Motion: nothing to animate, so the ordering is the whole job. The
+        // hierarchy is already staged at its final shape, so the window is taken to the
+        // frame that fits it before anything is drawn, and the setting is written
+        // behind that. Nothing is ever laid out taller than the window holding it, and
+        // implicit AppKit animations are off for the exchange, so neither the scroller
+        // nor the backdrop has anything to fade.
+        if duration == 0 {
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            window.setFrame(destination, display: false)
+            settings.update { $0.panel.collapsedModules = target }
+            withTransaction(transaction) {
+                layout.collapsedModulesOverride = nil
+                layout.isDisclosureTransitionActive = false
+            }
+            window.layoutIfNeeded()
+            window.displayIfNeeded()
+            CATransaction.commit()
+            isDisclosureTransitionActive = false
+            position(window, anchoredTo: lastAnchor, on: lastScreen)
+            return
+        }
 
         withTransaction(transaction) {
             layout.collapsedModulesOverride = current
@@ -239,16 +270,6 @@ public final class PanelController: NSObject, NSWindowDelegate {
         // Persist behind the presentation override so this write cannot restructure the
         // visible tree before the coordinated transition begins.
         settings.update { $0.panel.collapsedModules = target }
-
-        let duration = disclosureDuration
-        if duration == 0 {
-            withTransaction(transaction) {
-                layout.collapsedModulesOverride = target
-            }
-            window.setFrame(destination, display: true)
-            finishDisclosure(window: window, layout: layout)
-            return
-        }
 
         withAnimation(Design.Motion.disclosure) {
             layout.collapsedModulesOverride = target

--- a/Sources/AirStatUI/Panel/PanelController.swift
+++ b/Sources/AirStatUI/Panel/PanelController.swift
@@ -20,6 +20,8 @@ public final class PanelController: NSObject, NSWindowDelegate {
     /// Absent in the offscreen renderer. The panel's update row is drawn from it.
     private let updates: SoftwareUpdater?
     private var window: PanelWindow?
+    private var layout: PanelLayoutState?
+    private var isDisclosureTransitionActive = false
 
     /// Every `NSEvent` monitor and notification observer this controller owns, in one
     /// place. Two collections, one lifetime: they are installed together when the
@@ -138,6 +140,7 @@ public final class PanelController: NSObject, NSWindowDelegate {
             guard !Task.isCancelled, let self, !self.isVisible, let window = self.window else { return }
             self.releaseTask = nil
             self.window = nil
+            self.layout = nil
             self.lastAnchor = nil
             self.lastScreen = nil
             // Dropping the delegate first: `close` notifies it, and this controller has
@@ -161,7 +164,12 @@ public final class PanelController: NSObject, NSWindowDelegate {
 
     private func existingOrNewWindow() -> PanelWindow {
         if let window { return window }
-        let root = PanelRootView(engine: engine, settings: settings, updates: updates)
+        let layout = PanelLayoutState()
+        layout.toggleModule = { [weak self] module in
+            self?.toggleModule(module)
+        }
+        let root = PanelRootView(engine: engine, settings: settings, updates: updates,
+                                 layout: layout)
             .environment(\.panelActions, PanelActions(
                 openSettings: { [weak self] in self?.onRequestSettings?() },
                 quit: { [weak self] in self?.onRequestQuit?() },
@@ -177,11 +185,103 @@ public final class PanelController: NSObject, NSWindowDelegate {
         // Escape is handled here as well as by the key monitor, so it still works if
         // the panel is key but the monitor is not installed.
         window.onCancel = { [weak self] in self?.hide() }
+        self.layout = layout
         self.window = window
         return window
     }
 
     // MARK: Geometry
+
+    /// Toggle one module as a single AppKit/SwiftUI transaction.
+    ///
+    /// SwiftUI's intrinsic height is an animation value, so following each invalidation
+    /// makes the window chase the content one run-loop turn behind. Instead, stage the
+    /// final hierarchy synchronously to obtain one destination, restore the current
+    /// hierarchy before anything is displayed, then animate both systems to that one
+    /// destination. Intrinsic callbacks and resize delegate re-entry are ignored until
+    /// the transaction has completed.
+    func toggleModule(_ module: PanelModule) {
+        guard !isDisclosureTransitionActive else { return }
+
+        let current = settings.settings.panel.collapsedModules
+        var target = current
+        if target.contains(module) {
+            target.remove(module)
+        } else {
+            target.insert(module)
+        }
+
+        guard let window, isVisible, let layout else {
+            settings.update { $0.panel.collapsedModules = target }
+            return
+        }
+
+        isDisclosureTransitionActive = true
+        layout.isDisclosureTransitionActive = true
+
+        // Measure the final hierarchy without allowing the staging state to animate or
+        // reach the screen. The window itself remains on its current frame throughout.
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            layout.collapsedModulesOverride = target
+        }
+        window.layoutIfNeeded()
+        let fitting = window.contentView?.fittingSize
+            ?? NSSize(width: PanelSettings.width, height: window.frame.height)
+        let destination = targetFrame(for: fitting, anchoredTo: lastAnchor, on: lastScreen)
+
+        withTransaction(transaction) {
+            layout.collapsedModulesOverride = current
+        }
+        window.layoutIfNeeded()
+
+        // Persist behind the presentation override so this write cannot restructure the
+        // visible tree before the coordinated transition begins.
+        settings.update { $0.panel.collapsedModules = target }
+
+        let duration = disclosureDuration
+        if duration == 0 {
+            withTransaction(transaction) {
+                layout.collapsedModulesOverride = target
+            }
+            window.setFrame(destination, display: true)
+            finishDisclosure(window: window, layout: layout)
+            return
+        }
+
+        withAnimation(Design.Motion.disclosure) {
+            layout.collapsedModulesOverride = target
+        }
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = duration
+            context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+            window.animator().setFrame(destination, display: true)
+        } completionHandler: { [weak self, weak window, weak layout] in
+            MainActor.assumeIsolated {
+                guard let self, let window, let layout else { return }
+                self.finishDisclosure(window: window, layout: layout)
+            }
+        }
+    }
+
+    private var disclosureDuration: TimeInterval {
+        Design.Motion.respectingAccessibility(Design.Motion.disclosure) == nil
+            ? 0 : Design.Motion.disclosureDuration
+    }
+
+    private func finishDisclosure(window: NSWindow, layout: PanelLayoutState) {
+        var transaction = Transaction(animation: nil)
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            layout.collapsedModulesOverride = nil
+            layout.isDisclosureTransitionActive = false
+        }
+        isDisclosureTransitionActive = false
+        // Resolve any sub-point discrepancy between the measured destination and the
+        // final intrinsic size without producing a second visible move.
+        position(window, anchoredTo: lastAnchor, on: lastScreen)
+    }
 
     /// Anchor under the status item, nudged so the panel never hangs off the screen,
     /// slides under the menu bar, or grows past the bottom of the display.
@@ -194,6 +294,13 @@ public final class PanelController: NSObject, NSWindowDelegate {
         let fitting = window.contentView?.fittingSize
             ?? NSSize(width: PanelSettings.width, height: 400)
 
+        let frame = targetFrame(for: fitting, anchoredTo: anchor, on: screen)
+        guard frame != window.frame else { return }
+        window.setFrame(frame, display: true)
+    }
+
+    private func targetFrame(for fitting: NSSize, anchoredTo anchor: NSRect?,
+                             on screen: NSScreen?) -> NSRect {
         // The status item's own screen is the right one even when it is not the
         // primary: `visibleFrame` is in global coordinates, so a display whose menu
         // bar sits below or beside the primary's still resolves correctly.
@@ -201,7 +308,7 @@ public final class PanelController: NSObject, NSWindowDelegate {
             ?? anchor.flatMap(Self.screen(containing:))
             ?? NSScreen.main
             ?? NSScreen.screens.first
-        guard let visible = targetScreen?.visibleFrame else { return }
+        guard let visible = targetScreen?.visibleFrame else { return window?.frame ?? .zero }
 
         let margin = Design.Space.m
         let gap = Design.Space.s
@@ -245,10 +352,8 @@ public final class PanelController: NSObject, NSWindowDelegate {
         //
         // Setting the whole frame at once makes an unchanged placement a genuine no-op,
         // which is what stops the re-entrant pass from moving anything.
-        let frame = NSRect(x: x.rounded(), y: y.rounded(),
-                           width: size.width, height: size.height)
-        guard frame != window.frame else { return }
-        window.setFrame(frame, display: true)
+        return NSRect(x: x.rounded(), y: y.rounded(),
+                      width: size.width, height: size.height)
     }
 
     private static func screen(containing rect: NSRect) -> NSScreen? {
@@ -260,6 +365,7 @@ public final class PanelController: NSObject, NSWindowDelegate {
     /// SwiftUI can invalidate its size several times in one layout pass, so the
     /// window is re-measured once on the next turn rather than on every invalidation.
     private func scheduleContentResize() {
+        guard !isDisclosureTransitionActive else { return }
         guard !hasPendingResize else { return }
         hasPendingResize = true
         Task { @MainActor [weak self] in
@@ -275,7 +381,8 @@ public final class PanelController: NSObject, NSWindowDelegate {
     /// SwiftUI grows the window downwards from its bottom-left corner; re-running the
     /// placement re-pins it under the status item and re-applies the height cap.
     public func windowDidResize(_ notification: Notification) {
-        guard let window, isVisible, !isPositioning else { return }
+        guard let window, isVisible, !isPositioning,
+              !isDisclosureTransitionActive else { return }
         position(window, anchoredTo: lastAnchor, on: lastScreen)
     }
 

--- a/Sources/AirStatUI/Panel/PanelController.swift
+++ b/Sources/AirStatUI/Panel/PanelController.swift
@@ -392,7 +392,10 @@ public final class PanelController: NSObject, NSWindowDelegate {
         Task { @MainActor [weak self] in
             guard let self else { return }
             self.hasPendingResize = false
-            guard let window = self.window, self.isVisible else { return }
+            // A resize queued on the turn before a click would otherwise fire mid-
+            // transition and snap the window to the destination unanimated.
+            guard let window = self.window, self.isVisible,
+                  !self.isDisclosureTransitionActive else { return }
             self.position(window, anchoredTo: self.lastAnchor, on: self.lastScreen)
         }
     }

--- a/Sources/AirStatUI/Panel/PanelModuleView.swift
+++ b/Sources/AirStatUI/Panel/PanelModuleView.swift
@@ -28,6 +28,7 @@ struct PanelModuleView: View {
     let module: PanelModule
     let engine: MetricsEngine
     let settings: SettingsStore
+    var layout: PanelLayoutState?
 
     @State private var isHovering = false
 
@@ -39,7 +40,9 @@ struct PanelModuleView: View {
     }
 
     var isExpanded: Bool {
-        !settings.settings.panel.collapsedModules.contains(module)
+        let collapsed = layout?.collapsedModulesOverride
+            ?? settings.settings.panel.collapsedModules
+        return !collapsed.contains(module)
     }
 
     /// What the panel fills its bars and core cells with.
@@ -108,6 +111,8 @@ struct PanelModuleView: View {
             detail
                 .padding(.horizontal, Design.Space.panelInset)
                 .padding(.top, Design.Space.xxs)
+                .clipped()
+                .transition(.opacity)
         }
         .padding(.vertical, Design.Space.xxs)
         .environment(\.metricFormatter, formatter)
@@ -192,7 +197,11 @@ struct PanelModuleView: View {
     @ViewBuilder
     private var hoverHighlight: some View {
         RoundedRectangle(cornerRadius: Design.Radius.control, style: .continuous)
-            .fill(isHovering ? Design.Palette.track : .clear)
+            // Rows move under a stationary pointer during disclosure. Hiding the
+            // highlight while they travel prevents it flashing from one row to the
+            // next; onHover still tracks the final row underneath for the next frame.
+            .fill(isHovering && layout?.isDisclosureTransitionActive != true
+                  ? Design.Palette.track : .clear)
             .padding(.horizontal, Design.Space.s)
     }
 
@@ -246,20 +255,18 @@ struct PanelModuleView: View {
         }
     }
 
-    /// Deliberately not animated.
-    ///
-    /// The panel's window is sized to its content, so animating a disclosure animates
-    /// the window's own outline: the height is re-laid out every frame and the window
-    /// chases it a turn behind. Every version of that was some flavour of unsteady —
-    /// stepped, or bouncing, or dragging the whole table with it — and none of the
-    /// motion was carrying information. Opening on the same frame as the click is both
-    /// steadier and quicker to read.
     private func toggleCollapsed() {
-        settings.update { s in
-            if s.panel.collapsedModules.contains(module) {
-                s.panel.collapsedModules.remove(module)
-            } else {
-                s.panel.collapsedModules.insert(module)
+        if let coordinate = layout?.toggleModule {
+            coordinate(module)
+            return
+        }
+        withAnimation(Design.Motion.respectingAccessibility(Design.Motion.disclosure)) {
+            settings.update { s in
+                if s.panel.collapsedModules.contains(module) {
+                    s.panel.collapsedModules.remove(module)
+                } else {
+                    s.panel.collapsedModules.insert(module)
+                }
             }
         }
     }

--- a/Sources/AirStatUI/Panel/PanelRootView.swift
+++ b/Sources/AirStatUI/Panel/PanelRootView.swift
@@ -1,6 +1,18 @@
 import SwiftUI
 import AppKit
+import Observation
 import AirStatKit
+
+/// Ephemeral presentation state shared by the panel's SwiftUI tree and its AppKit
+/// controller. Settings remain the durable truth; the override exists only long enough
+/// to measure and animate one disclosure as a coordinated transaction.
+@MainActor
+@Observable
+final class PanelLayoutState {
+    var collapsedModulesOverride: Set<PanelModule>?
+    var isDisclosureTransitionActive = false
+    @ObservationIgnored var toggleModule: ((PanelModule) -> Void)?
+}
 
 /// Root of the click-down panel.
 ///
@@ -13,11 +25,22 @@ public struct PanelRootView: View {
     private let settings: SettingsStore
     /// Absent in the offscreen renderer, which has no Sparkle to ask.
     private let updates: SoftwareUpdater?
+    /// Absent in renderers and previews, where disclosure writes settings directly.
+    private let layout: PanelLayoutState?
 
     public init(engine: MetricsEngine, settings: SettingsStore, updates: SoftwareUpdater? = nil) {
         self.engine = engine
         self.settings = settings
         self.updates = updates
+        self.layout = nil
+    }
+
+    init(engine: MetricsEngine, settings: SettingsStore, updates: SoftwareUpdater?,
+         layout: PanelLayoutState) {
+        self.engine = engine
+        self.settings = settings
+        self.updates = updates
+        self.layout = layout
     }
 
     public var body: some View {
@@ -35,7 +58,8 @@ public struct PanelRootView: View {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(modules.enumerated()), id: \.element) { index, module in
                         if index > 0 { PanelSeparator(isVisible: separatorNeeded(before: index)) }
-                        PanelModuleView(module: module, engine: engine, settings: settings)
+                        PanelModuleView(module: module, engine: engine, settings: settings,
+                                        layout: layout)
                     }
                 }
                 .padding(.vertical, Design.Space.xs)
@@ -63,7 +87,8 @@ public struct PanelRootView: View {
     /// list. So a separator appears only where an expanded module begins or ends, which
     /// is exactly where the eye needs to know a block started.
     private func separatorNeeded(before index: Int) -> Bool {
-        let collapsed = settings.settings.panel.collapsedModules
+        let collapsed = layout?.collapsedModulesOverride
+            ?? settings.settings.panel.collapsedModules
         let previous = modules[index - 1]
         let current = modules[index]
         return !collapsed.contains(previous) || !collapsed.contains(current)

--- a/Sources/AirStatUI/Panel/PanelRootView.swift
+++ b/Sources/AirStatUI/Panel/PanelRootView.swift
@@ -65,6 +65,19 @@ public struct PanelRootView: View {
                 .padding(.vertical, Design.Space.xs)
             }
             .scrollBounceBehavior(.basedOnSize)
+            // No indicator, ever.
+            //
+            // The window is sized to this list, so in the ordinary case there is
+            // nothing to scroll and nothing for an indicator to report. What it does
+            // instead is flicker: every change in content height leaves one layout pass
+            // in which the list is taller than the window that has not yet grown to
+            // hold it, and the scroll view spends that pass showing a scroller. Under
+            // `Show scroll bars: Always` that scroller is a legacy one, so it also
+            // takes real width and reflows the text beneath it on the way in and out.
+            // `.never` rather than `.automatic`, because `.hidden` still defers to that
+            // setting. The list stays scrollable by trackpad and wheel for the rare
+            // case that it reaches the ceiling below.
+            .scrollIndicators(.never)
             .defaultScrollAnchor(.top)
             .fixedSize(horizontal: false, vertical: true)
             .frame(maxHeight: Self.maximumModuleHeight)

--- a/Tests/AirStatKitTests/TortureTests.swift
+++ b/Tests/AirStatKitTests/TortureTests.swift
@@ -160,6 +160,27 @@ struct WindowTortureTests {
         #expect(controller.activeEventMonitorCount == 0)
     }
 
+    @Test("a disclosure resizes once while keeping the panel's top edge anchored")
+    func disclosureResizesFromTopEdge() async throws {
+        let s = store()
+        let engine = MetricsEngine(settingsStore: s)
+        engine.loadFixture(snapshot: SnapshotFixtures.nominal,
+                           history: MetricHistory(capacity: 60, sampleInterval: 1))
+        let controller = PanelController(engine: engine, settings: s)
+        controller.show(anchoredTo: nil, on: NSScreen.main)
+        let window = try #require(NSApp.windows.first { $0.isVisible })
+        let before = window.frame
+
+        controller.toggleModule(.memory)
+        try await Task.sleep(for: .milliseconds(250))
+
+        #expect(window.frame.height > before.height,
+                "panel did not grow from \(before.height): \(window.frame.height)")
+        #expect(abs(window.frame.maxY - before.maxY) < 1,
+                "panel top moved from \(before.maxY) to \(window.frame.maxY)")
+        controller.hide()
+    }
+
     /// Anchors off the bottom, off the side, and on no screen at all. The placement
     /// clamps rather than producing a window nobody can reach.
     ///


### PR DESCRIPTION
## Summary
- coordinate SwiftUI disclosure motion with one AppKit window-frame animation
- keep the panel dynamically sized and anchored beneath the menu bar
- suppress re-entrant resize and hover flicker during the transition
- respect Reduce Motion and preserve direct settings behavior in previews

## Testing
- `swift test` (230 tests passed)