### PR TITLE
fix(panel): shrink the per-core slot so wide clusters fit the panel

### DIFF
--- a/Sources/AirStatUI/Panel/PanelComponents.swift
+++ b/Sources/AirStatUI/Panel/PanelComponents.swift
@@ -114,7 +114,8 @@ struct PanelCoreRow: View {
     let loads: [CPULoad]
     let busy: Double?
     let tint: Color
-    var labelWidth: CGFloat = 58
+    var slotWidth: CGFloat = PanelCoreRow.preferredSlotWidth
+    var labelWidth: CGFloat = PanelCoreRow.defaultLabelWidth
 
     @Environment(\.metricFormatter) private var formatter
 
@@ -132,7 +133,35 @@ struct PanelCoreRow: View {
     /// a five-core row sharing the same width would draw noticeably different bar
     /// widths. Pinning the slot keeps a core the same size in both rows and lets the
     /// six-core strip run visibly longer, which is the truth about the machine.
-    private static let slotWidth: CGFloat = 28
+    ///
+    /// Preferred, not absolute. Ten P-cores at 28pt want 280pt of strip in a row that
+    /// has about 206pt to give once the label, the gaps and the value are out, and a
+    /// 24-core Ultra wants 672. Past that point the strip pushed every row in the
+    /// panel out through both sides of the window. `slotWidth(sharedAcross:)` shrinks
+    /// the slot until the widest cluster fits, and the caller hands the same answer to
+    /// every row so the two clusters still draw their cores at one size.
+    static let preferredSlotWidth: CGFloat = 28
+
+    /// Wider than the detail rows' 58pt column by the width of a second digit: an
+    /// Ultra's "24 P-cores" was the one label in the panel that truncated.
+    static let defaultLabelWidth: CGFloat = 64
+
+    /// Width held for the value column so the strip budget is honest at "100%".
+    private static let valueReserve: CGFloat = 36
+
+    /// What is left for the strip once the label, the value, the stack's three gaps
+    /// and the spacer's minimum are taken out of the panel's content width.
+    private static var stripBudget: CGFloat {
+        CGFloat(PanelSettings.width) - 2 * Design.Space.panelInset
+            - defaultLabelWidth - 4 * Design.Space.m - valueReserve
+    }
+
+    /// The slot every core row should use when the widest of them has `widestCluster`
+    /// cores: the preferred width, or the largest that fits.
+    static func slotWidth(sharedAcross widestCluster: Int) -> CGFloat {
+        guard widestCluster > 0 else { return preferredSlotWidth }
+        return min(preferredSlotWidth, stripBudget / CGFloat(widestCluster))
+    }
 
     var body: some View {
         HStack(spacing: Design.Space.m) {
@@ -143,11 +172,12 @@ struct PanelCoreRow: View {
                 .frame(width: labelWidth, alignment: .leading)
             CoreGrid(cores: loads, tint: tint, height: Self.stripHeight,
                      showsClusterLabels: false)
-                .frame(width: CGFloat(loads.count) * Self.slotWidth)
+                .frame(width: CGFloat(loads.count) * slotWidth)
             Spacer(minLength: Design.Space.m)
             Text(busy.map { formatter.percent($0) } ?? MetricFormatter.unavailable)
                 .font(Design.Text.value)
                 .foregroundStyle(Design.Palette.primaryText)
+                .fixedSize()
         }
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(loads.count) \(label)")

--- a/Sources/AirStatUI/Panel/PanelModuleDetails.swift
+++ b/Sources/AirStatUI/Panel/PanelModuleDetails.swift
@@ -60,14 +60,16 @@ extension PanelModuleView {
         if efficiency.isEmpty || performance.isEmpty {
             if !cpu.perCore.isEmpty {
                 PanelCoreRow(label: "\(cpu.perCore.count) cores", loads: cpu.perCore,
-                             busy: cpu.total.busy, tint: tint)
+                             busy: cpu.total.busy, tint: tint,
+                             slotWidth: PanelCoreRow.slotWidth(sharedAcross: cpu.perCore.count))
             }
         } else {
+            let slot = PanelCoreRow.slotWidth(sharedAcross: max(efficiency.count, performance.count))
             VStack(alignment: .leading, spacing: Design.Space.xs) {
                 PanelCoreRow(label: "\(efficiency.count) E-cores", loads: efficiency,
-                             busy: cpu.efficiencyBusy, tint: tint)
+                             busy: cpu.efficiencyBusy, tint: tint, slotWidth: slot)
                 PanelCoreRow(label: "\(performance.count) P-cores", loads: performance,
-                             busy: cpu.performanceBusy, tint: tint)
+                             busy: cpu.performanceBusy, tint: tint, slotWidth: slot)
             }
         }
     }

--- a/Tests/AirStatKitTests/PanelCoreRowTests.swift
+++ b/Tests/AirStatKitTests/PanelCoreRowTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import Foundation
+import SwiftUI
+import AppKit
+@testable import AirStatKit
+@testable import AirStatUI
+
+@MainActor
+@Suite("Panel core rows")
+struct PanelCoreRowTests {
+
+    private var contentWidth: CGFloat {
+        CGFloat(PanelSettings.width) - 2 * Design.Space.panelInset
+    }
+
+    private func fittingWidth(of view: some View) -> CGFloat {
+        let host = NSHostingView(rootView: view)
+        host.sizingOptions = [.intrinsicContentSize]
+        host.layoutSubtreeIfNeeded()
+        return host.fittingSize.width
+    }
+
+    private func row(cores count: Int, slot: CGFloat) -> PanelCoreRow {
+        let loads = Array(repeating: CPULoad(user: 1, system: 0, idle: 0), count: count)
+        return PanelCoreRow(label: "\(count) P-cores", loads: loads, busy: 1,
+                            tint: .red, slotWidth: slot)
+    }
+
+    /// The M4 Max ships ten P-cores and the M3 Ultra twenty-four. At the preferred
+    /// slot either cluster is wider than the panel, and the row used to push every
+    /// module under it out through both sides of the window.
+    @Test("a wide cluster at its shared slot fits the panel's content width",
+          arguments: [8, 10, 12, 16, 24, 32])
+    func wideClusterFits(count: Int) {
+        let slot = PanelCoreRow.slotWidth(sharedAcross: count)
+        let width = fittingWidth(of: row(cores: count, slot: slot))
+        #expect(width <= contentWidth + 0.5, "\(count) cores need \(width)pt of \(contentWidth)")
+    }
+
+    @Test("a cluster that fits keeps the preferred slot")
+    func smallClusterKeepsPreferredSlot() {
+        #expect(PanelCoreRow.slotWidth(sharedAcross: 6) == PanelCoreRow.preferredSlotWidth)
+        #expect(PanelCoreRow.slotWidth(sharedAcross: 0) == PanelCoreRow.preferredSlotWidth)
+    }
+
+    @Test("the shared slot is narrower than the preferred one only when it has to be")
+    func slotShrinksOnlyWhenNeeded() {
+        let ten = PanelCoreRow.slotWidth(sharedAcross: 10)
+        let twentyFour = PanelCoreRow.slotWidth(sharedAcross: 24)
+        #expect(ten < PanelCoreRow.preferredSlotWidth)
+        #expect(twentyFour < ten)
+        #expect(twentyFour > 2)
+    }
+}


### PR DESCRIPTION
Fixes the horizontal overflow reported in discussion #9.

## Cause

Each core in the expanded CPU view gets a fixed 28pt slot, and the strip's frame is pinned to core count times slot. The row has about 180pt to give once the label, the value and the stack gaps are taken out, so any cluster past six or seven cores is wider than the panel. The row is a fixed-width child, so the whole module stack grew and every module below CPU spilled through both sides of the window. The bundled fixtures use six E-cores and five P-cores, which is why it never showed locally.

## Fix

- 28pt is now the preferred slot. `PanelCoreRow.slotWidth(sharedAcross:)` returns it when it fits and otherwise the widest slot that fits the panel for the largest cluster.
- The CPU detail computes the slot once from the wider cluster and hands it to both rows, so E-core and P-core bars still draw at one size.
- The value text is fixed-size so the strip can never squeeze it.
- The core row label column is 64pt instead of 58pt so an Ultra's "24 P-cores" no longer truncates.

| Cluster | Slot |
|---|---|
| up to 6 cores | 28pt (unchanged) |
| 10 P-cores | 18pt |
| 24 P-cores | 7.5pt |

## Verification

New `PanelCoreRowTests` measures a row's fitting width at 8, 10, 12, 16, 24 and 32 cores and asserts it fits the panel's content width. Full suite passes locally (219 tests). Rendered the expanded panel offscreen for 4E+10P, 8E+24P and 6E+5P and checked all three fit.